### PR TITLE
fix: use version from version.properties instead of hardcoded value

### DIFF
--- a/summon-core/build.gradle.kts
+++ b/summon-core/build.gradle.kts
@@ -1,12 +1,8 @@
 import java.security.MessageDigest
 import java.util.*
 
-// Apply version management
+// Apply version management - sets project.version and project.group from version.properties
 apply(from = "../version.gradle.kts")
-
-// Manual version override for now
-version = "0.5.4.2"
-group = "codes.yousef"
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)


### PR DESCRIPTION
This pull request makes a small update to the `summon-core/build.gradle.kts` build configuration by removing manual overrides for the project version and group. The project will now rely on the shared version management script for these values.