### PR TITLE
FEL-642: add typed SSR styling and form APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0.3] - 2026-07-17
+
+### Added
+
+- **Typed stylesheet DSL** - Structured selectors, pseudo-classes, pseudo-elements, media queries,
+  keyframes, rule priorities, and animation values for declaring reusable styles without raw CSS
+- **Conditional modifier styles** - State, scoped-selector, and media-query styles now render on JVM
+  SSR and attach the required state hooks in browser runtimes
+- **Typed CSS modifiers** - Added APIs for text wrapping and overflow, outlines, logical insets,
+  scrollbar styling, grid tracks, color schemes, list styles, sizing, and text shadows
+- **Native form metadata** - Added search and date inputs, maximum-length and numeric-step constraints,
+  radio groups, and submit-button name, value, and form targeting
+
+### Changed
+
+- **JVM head rendering** - Custom head declarations now supersede matching defaults, declarations made
+  during composition are included in the final document, and repeated renders do not leak head state
+- **Typed rendering coverage** - Expanded typed background, border, accessibility, transition, grid, and
+  text helpers used by framework-only SSR applications
+
+### Fixed
+
+- **Head output escaping** - Titles, attributes, and raw-text end tags are escaped to prevent malformed
+  or prematurely terminated head elements
+- **Binary compatibility** - Preserved the existing JVM signatures for form fields and buttons while
+  exposing the new optional form metadata
+
 ## [0.7.0.2] - 2026-02-10
 
 ### Fixed

--- a/summon-core/api/summon-core.api
+++ b/summon-core/api/summon-core.api
@@ -2290,16 +2290,22 @@ public final class codes/yousef/summon/components/forms/FormFieldMetadata {
 }
 
 public final class codes/yousef/summon/components/forms/FormFieldsKt {
-	public static final fun FormButton (Ljava/lang/String;Lcodes/yousef/summon/components/forms/FormButtonType;Lcodes/yousef/summon/components/forms/FormButtonVariant;Lcodes/yousef/summon/modifier/Modifier;ZLjava/lang/String;)V
+	public static final synthetic fun FormButton (Ljava/lang/String;Lcodes/yousef/summon/components/forms/FormButtonType;Lcodes/yousef/summon/components/forms/FormButtonVariant;Lcodes/yousef/summon/modifier/Modifier;ZLjava/lang/String;)V
+	public static final fun FormButton (Ljava/lang/String;Lcodes/yousef/summon/components/forms/FormButtonType;Lcodes/yousef/summon/components/forms/FormButtonVariant;Lcodes/yousef/summon/modifier/Modifier;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun FormButton$default (Ljava/lang/String;Lcodes/yousef/summon/components/forms/FormButtonType;Lcodes/yousef/summon/components/forms/FormButtonVariant;Lcodes/yousef/summon/modifier/Modifier;ZLjava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun FormButton$default (Ljava/lang/String;Lcodes/yousef/summon/components/forms/FormButtonType;Lcodes/yousef/summon/components/forms/FormButtonVariant;Lcodes/yousef/summon/modifier/Modifier;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static final fun FormCheckbox (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)V
 	public static synthetic fun FormCheckbox$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun FormRadioGroup (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)V
+	public static synthetic fun FormRadioGroup$default (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;ILjava/lang/Object;)V
 	public static final fun FormSelect (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)V
 	public static synthetic fun FormSelect$default (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;ILjava/lang/Object;)V
 	public static final fun FormTextArea (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)V
 	public static synthetic fun FormTextArea$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun FormTextField (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/components/forms/FormTextFieldType;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)V
+	public static final synthetic fun FormTextField (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/components/forms/FormTextFieldType;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)V
+	public static final fun FormTextField (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/components/forms/FormTextFieldType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Number;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)V
 	public static synthetic fun FormTextField$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/components/forms/FormTextFieldType;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun FormTextField$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/components/forms/FormTextFieldType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Number;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class codes/yousef/summon/components/forms/FormHiddenField {
@@ -2324,6 +2330,22 @@ public final class codes/yousef/summon/components/forms/FormMethod : java/lang/E
 	public static fun values ()[Lcodes/yousef/summon/components/forms/FormMethod;
 }
 
+public final class codes/yousef/summon/components/forms/FormRadioOption {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lcodes/yousef/summon/components/forms/FormRadioOption;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/components/forms/FormRadioOption;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcodes/yousef/summon/components/forms/FormRadioOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisabled ()Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class codes/yousef/summon/components/forms/FormSelectOption {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -2341,9 +2363,11 @@ public final class codes/yousef/summon/components/forms/FormSelectOption {
 }
 
 public final class codes/yousef/summon/components/forms/FormTextFieldType : java/lang/Enum {
+	public static final field Date Lcodes/yousef/summon/components/forms/FormTextFieldType;
 	public static final field Email Lcodes/yousef/summon/components/forms/FormTextFieldType;
 	public static final field Number Lcodes/yousef/summon/components/forms/FormTextFieldType;
 	public static final field Password Lcodes/yousef/summon/components/forms/FormTextFieldType;
+	public static final field Search Lcodes/yousef/summon/components/forms/FormTextFieldType;
 	public static final field Tel Lcodes/yousef/summon/components/forms/FormTextFieldType;
 	public static final field Text Lcodes/yousef/summon/components/forms/FormTextFieldType;
 	public static final field Url Lcodes/yousef/summon/components/forms/FormTextFieldType;
@@ -2667,6 +2691,187 @@ public final class codes/yousef/summon/components/foundation/ThemeProviderKt {
 	public static final fun themeColor (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun themeSpacing (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun useTheme ()Lcodes/yousef/summon/components/foundation/EnhancedThemeConfig;
+}
+
+public final class codes/yousef/summon/components/html/DetailsElementsKt {
+	public static final fun Details (ZLkotlin/jvm/functions/Function1;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Details$default (ZLkotlin/jvm/functions/Function1;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Dialog (ZLcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Dialog$default (ZLcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Summary (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Summary$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/components/html/HtmlElementsKt {
+	public static final fun Address (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Address$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Article (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Article$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Aside (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Aside$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Footer (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Footer$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Header (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Header$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Hgroup (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Hgroup$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Main (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Main$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Nav (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Nav$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Search (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Search$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Section (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Section$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/components/html/InlineElementsKt {
+	public static final fun A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun A$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Abbr (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Abbr$default (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Bdi (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Bdi$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Bdo (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Bdo$default (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Br (Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Br$default (Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+	public static final fun Cite (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Cite$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Data (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Data$default (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Dfn (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Dfn$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Kbd (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Kbd$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Q (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Q$default (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Rp (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Rp$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Rt (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Rt$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Ruby (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Ruby$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Samp (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Samp$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Span (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Span$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Time (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Time$default (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Var (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Var$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Wbr (Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Wbr$default (Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/components/html/ListElementsKt {
+	public static final fun Dd (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Dd$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Dl (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Dl$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Dt (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Dt$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Li (Ljava/lang/Integer;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Li$default (Ljava/lang/Integer;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Menu (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Menu$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Ol (Ljava/lang/Integer;ZLjava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Ol$default (Ljava/lang/Integer;ZLjava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Ul (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Ul$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/components/html/MediaElementsKt {
+	public static final fun Audio (Ljava/lang/String;ZZZZLjava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Audio$default (Ljava/lang/String;ZZZZLjava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Embed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Embed$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+	public static final fun Figcaption (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Figcaption$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Figure (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Figure$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Iframe (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Iframe$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+	public static final fun Meter (DDDLjava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Meter$default (DDDLjava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun ObjectTag (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun ObjectTag$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Param (Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Param$default (Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+	public static final fun Source (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Source$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+	public static final fun Track (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Track$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/components/html/TableElementsKt {
+	public static final fun Caption (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Caption$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Col (Ljava/lang/Integer;Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun Col$default (Ljava/lang/Integer;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+	public static final fun Colgroup (Ljava/lang/Integer;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Colgroup$default (Ljava/lang/Integer;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Table (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Table$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Tbody (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Tbody$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Td (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Td$default (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Tfoot (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Tfoot$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Th (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Th$default (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Thead (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Thead$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Tr (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Tr$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/components/html/TextElementsKt {
+	public static final fun B (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun B$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Blockquote (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Blockquote$default (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Code (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Code$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Del (Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Del$default (Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Em (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Em$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun H1 (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun H1$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun H2 (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun H2$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun H3 (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun H3$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun H4 (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun H4$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun H5 (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun H5$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun H6 (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun H6$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun I (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun I$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Ins (Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Ins$default (Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Mark (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Mark$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun P (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun P$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Pre (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Pre$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun S (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun S$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Small (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Small$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Strong (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Strong$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Sub (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Sub$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun Sup (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun Sup$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun U (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun U$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class codes/yousef/summon/components/input/ButtonKt {
@@ -3231,6 +3436,69 @@ public final class codes/yousef/summon/components/navigation/TabLayoutKt {
 	public static synthetic fun TabLayout$default (Ljava/util/List;ILkotlin/jvm/functions/Function1;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
 }
 
+public final class codes/yousef/summon/components/styles/AnimationEasing : java/lang/Enum {
+	public static final field Ease Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static final field EaseIn Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static final field EaseInOut Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static final field EaseOut Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static final field Linear Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static final field StepEnd Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static final field StepStart Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/AnimationEasing;
+	public static fun values ()[Lcodes/yousef/summon/components/styles/AnimationEasing;
+}
+
+public abstract class codes/yousef/summon/components/styles/AnimationIterationCount {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class codes/yousef/summon/components/styles/AnimationIterationCount$Infinite : codes/yousef/summon/components/styles/AnimationIterationCount {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/AnimationIterationCount$Infinite;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/AnimationIterationCount$Once : codes/yousef/summon/components/styles/AnimationIterationCount {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/AnimationIterationCount$Once;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/AnimationIterationCount$Times : codes/yousef/summon/components/styles/AnimationIterationCount {
+	public fun <init> (I)V
+}
+
+public final class codes/yousef/summon/components/styles/AnimationName {
+	public static final field Companion Lcodes/yousef/summon/components/styles/AnimationName$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/AnimationName;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/AnimationName$Companion {
+	public final fun named-UdnWQyA (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/AttributeMatch : java/lang/Enum {
+	public static final field Contains Lcodes/yousef/summon/components/styles/AttributeMatch;
+	public static final field EndsWith Lcodes/yousef/summon/components/styles/AttributeMatch;
+	public static final field Equals Lcodes/yousef/summon/components/styles/AttributeMatch;
+	public static final field IncludesWord Lcodes/yousef/summon/components/styles/AttributeMatch;
+	public static final field StartsWith Lcodes/yousef/summon/components/styles/AttributeMatch;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/AttributeMatch;
+	public static fun values ()[Lcodes/yousef/summon/components/styles/AttributeMatch;
+}
+
 public final class codes/yousef/summon/components/styles/GlobalStyleKt {
 	public static final fun CssVariables (Ljava/util/Map;Lcodes/yousef/summon/modifier/Modifier;)V
 	public static synthetic fun CssVariables$default (Ljava/util/Map;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
@@ -3252,6 +3520,242 @@ public final class codes/yousef/summon/components/styles/GradientThemes {
 	public final fun getModernPrimary ()Ljava/util/Map;
 }
 
+public final class codes/yousef/summon/components/styles/StyleAttribute {
+	public static final field Companion Lcodes/yousef/summon/components/styles/StyleAttribute$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class codes/yousef/summon/components/styles/StyleAttribute$Companion {
+	public final fun aria (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun data (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getAriaCurrent ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getAriaExpanded ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getChecked ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getDirection ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getDisabled ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getHidden ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getLanguage ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getOpen ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getRole ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getSelected ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getStyle ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+	public final fun getType ()Lcodes/yousef/summon/components/styles/StyleAttribute;
+}
+
+public final class codes/yousef/summon/components/styles/StyleElement : java/lang/Enum {
+	public static final field Anchor Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Article Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Aside Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Audio Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Body Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Button Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Canvas Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Code Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Details Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Div Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Footer Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Form Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Header Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Heading1 Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Heading2 Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Heading3 Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Heading4 Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Heading5 Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Heading6 Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Html Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Iframe Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Image Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Input Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Label Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field List Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field ListItem Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Main Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Nav Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Option Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field OrderedList Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Paragraph Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Preformatted Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Section Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Select Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Span Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Summary Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Table Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field TableBody Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field TableCell Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field TableHead Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field TableHeader Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field TableRow Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field TextArea Lcodes/yousef/summon/components/styles/StyleElement;
+	public static final field Video Lcodes/yousef/summon/components/styles/StyleElement;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StyleElement;
+	public static fun values ()[Lcodes/yousef/summon/components/styles/StyleElement;
+}
+
+public abstract class codes/yousef/summon/components/styles/StylePseudoClass {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$Active : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$Active;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$Checked : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$Checked;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$Disabled : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$Disabled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$Empty : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$Empty;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$FirstChild : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$FirstChild;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$Focus : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$Focus;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$FocusVisible : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$FocusVisible;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$FocusWithin : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$FocusWithin;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$Hover : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$Hover;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$LastChild : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$LastChild;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$NthChild : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field Companion Lcodes/yousef/summon/components/styles/StylePseudoClass$NthChild$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$NthChild$Companion {
+	public final fun getEven ()Lcodes/yousef/summon/components/styles/StylePseudoClass$NthChild;
+	public final fun getOdd ()Lcodes/yousef/summon/components/styles/StylePseudoClass$NthChild;
+	public final fun index (I)Lcodes/yousef/summon/components/styles/StylePseudoClass$NthChild;
+	public final fun sequence (II)Lcodes/yousef/summon/components/styles/StylePseudoClass$NthChild;
+	public static synthetic fun sequence$default (Lcodes/yousef/summon/components/styles/StylePseudoClass$NthChild$Companion;IIILjava/lang/Object;)Lcodes/yousef/summon/components/styles/StylePseudoClass$NthChild;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$OnlyChild : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$OnlyChild;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoClass$Visited : codes/yousef/summon/components/styles/StylePseudoClass {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StylePseudoClass$Visited;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StylePseudoElement : java/lang/Enum {
+	public static final field After Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field Before Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field FileSelectorButton Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field Marker Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field Placeholder Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field Selection Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field WebkitDetailsMarker Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field WebkitScrollbar Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field WebkitScrollbarThumb Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field WebkitScrollbarTrack Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field WebkitSearchCancelButton Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static final field WebkitSliderThumb Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StylePseudoElement;
+	public static fun values ()[Lcodes/yousef/summon/components/styles/StylePseudoElement;
+}
+
+public final class codes/yousef/summon/components/styles/StyleRulePriority : java/lang/Enum {
+	public static final field Important Lcodes/yousef/summon/components/styles/StyleRulePriority;
+	public static final field Normal Lcodes/yousef/summon/components/styles/StyleRulePriority;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StyleRulePriority;
+	public static fun values ()[Lcodes/yousef/summon/components/styles/StyleRulePriority;
+}
+
+public abstract class codes/yousef/summon/components/styles/StyleSelector {
+	public static final field Companion Lcodes/yousef/summon/components/styles/StyleSelector$Companion;
+	public final fun adjacentSibling (Lcodes/yousef/summon/components/styles/StyleSelector;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun attribute (Lcodes/yousef/summon/components/styles/StyleAttribute;Ljava/lang/String;Lcodes/yousef/summon/components/styles/AttributeMatch;Z)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public static synthetic fun attribute$default (Lcodes/yousef/summon/components/styles/StyleSelector;Lcodes/yousef/summon/components/styles/StyleAttribute;Ljava/lang/String;Lcodes/yousef/summon/components/styles/AttributeMatch;ZILjava/lang/Object;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun child (Lcodes/yousef/summon/components/styles/StyleSelector;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun descendant (Lcodes/yousef/summon/components/styles/StyleSelector;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun generalSibling (Lcodes/yousef/summon/components/styles/StyleSelector;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun not (Lcodes/yousef/summon/components/styles/StyleSelector;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun or (Lcodes/yousef/summon/components/styles/StyleSelector;[Lcodes/yousef/summon/components/styles/StyleSelector;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun pseudoClass (Lcodes/yousef/summon/components/styles/StylePseudoClass;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun pseudoElement (Lcodes/yousef/summon/components/styles/StylePseudoElement;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun withClass (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StyleSelector;
+}
+
+public final class codes/yousef/summon/components/styles/StyleSelector$Companion {
+	public final fun all (Lcodes/yousef/summon/components/styles/StyleSelector;Lcodes/yousef/summon/components/styles/StyleSelector;[Lcodes/yousef/summon/components/styles/StyleSelector;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun all (Ljava/lang/Iterable;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun className (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun element (Lcodes/yousef/summon/components/styles/StyleElement;)Lcodes/yousef/summon/components/styles/StyleSelector;
+	public final fun id (Ljava/lang/String;)Lcodes/yousef/summon/components/styles/StyleSelector;
+}
+
+public final class codes/yousef/summon/components/styles/StyleSelector$Root : codes/yousef/summon/components/styles/StyleSelector {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StyleSelector$Root;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/StyleSelector$Universal : codes/yousef/summon/components/styles/StyleSelector {
+	public static final field INSTANCE Lcodes/yousef/summon/components/styles/StyleSelector$Universal;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class codes/yousef/summon/components/styles/ThemeConfig {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
@@ -3271,6 +3775,25 @@ public final class codes/yousef/summon/components/styles/ThemeConfig {
 	public final fun getTypography ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/components/styles/TypedKeyframesScope {
+	public final fun frame (ILcodes/yousef/summon/modifier/Modifier;)V
+	public final fun from (Lcodes/yousef/summon/modifier/Modifier;)V
+	public final fun to (Lcodes/yousef/summon/modifier/Modifier;)V
+}
+
+public final class codes/yousef/summon/components/styles/TypedStyleSheetKt {
+	public static final fun TypedStyleSheet (Lkotlin/jvm/functions/Function1;)V
+	public static final fun animation-qn0-_wc (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lcodes/yousef/summon/modifier/AnimationDuration;Lcodes/yousef/summon/components/styles/AnimationEasing;Lcodes/yousef/summon/modifier/AnimationDuration;Lcodes/yousef/summon/components/styles/AnimationIterationCount;Lcodes/yousef/summon/modifier/AnimationDirection;Lcodes/yousef/summon/modifier/AnimationFillMode;)Lcodes/yousef/summon/modifier/Modifier;
+	public static synthetic fun animation-qn0-_wc$default (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lcodes/yousef/summon/modifier/AnimationDuration;Lcodes/yousef/summon/components/styles/AnimationEasing;Lcodes/yousef/summon/modifier/AnimationDuration;Lcodes/yousef/summon/components/styles/AnimationIterationCount;Lcodes/yousef/summon/modifier/AnimationDirection;Lcodes/yousef/summon/modifier/AnimationFillMode;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
+}
+
+public final class codes/yousef/summon/components/styles/TypedStyleSheetScope {
+	public final fun keyframes-Cp4UYnY (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun media (Lcodes/yousef/summon/modifier/MediaQuery;Lkotlin/jvm/functions/Function1;)V
+	public final fun rule (Lcodes/yousef/summon/components/styles/StyleSelector;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/components/styles/StyleRulePriority;)V
+	public static synthetic fun rule$default (Lcodes/yousef/summon/components/styles/TypedStyleSheetScope;Lcodes/yousef/summon/components/styles/StyleSelector;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/components/styles/StyleRulePriority;ILjava/lang/Object;)V
 }
 
 public final class codes/yousef/summon/core/BrowserInfo {
@@ -3968,6 +4491,599 @@ public final class codes/yousef/summon/css/CssSanitizer {
 	public static final field INSTANCE Lcodes/yousef/summon/css/CssSanitizer;
 	public final fun sanitize (Ljava/lang/String;)Ljava/lang/String;
 	public final fun validate (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class codes/yousef/summon/desktop/communication/BroadcastChannelJvm {
+	public static final fun createBroadcastChannel (Ljava/lang/String;)Lcodes/yousef/summon/desktop/communication/SummonBroadcastChannel;
+}
+
+public final class codes/yousef/summon/desktop/communication/BroadcastChannelKt {
+	public static final fun createTypedBroadcastChannel (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/desktop/communication/SummonBroadcastChannel;
+	public static final fun typedBroadcastChannel (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/desktop/communication/SummonBroadcastChannel;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragCoordinator {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun acceptDrop (Ljava/lang/String;)V
+	public final fun addListener (Lcodes/yousef/summon/desktop/communication/DragEventListener;)V
+	public final fun close ()V
+	public final fun endDrag (Ljava/lang/String;Z)V
+	public static synthetic fun endDrag$default (Lcodes/yousef/summon/desktop/communication/DragCoordinator;Ljava/lang/String;ZILjava/lang/Object;)V
+	public final fun removeListener (Lcodes/yousef/summon/desktop/communication/DragEventListener;)V
+	public final fun startDrag (Lcodes/yousef/summon/desktop/communication/DragData;)V
+	public final fun updateDragPosition (Ljava/lang/String;DD)V
+}
+
+public final class codes/yousef/summon/desktop/communication/DragData {
+	public static final field Companion Lcodes/yousef/summon/desktop/communication/DragData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcodes/yousef/summon/desktop/communication/DragData;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/communication/DragData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/communication/DragData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataType ()Ljava/lang/String;
+	public final fun getDragId ()Ljava/lang/String;
+	public final fun getMetadata ()Ljava/util/Map;
+	public final fun getPayload ()Ljava/lang/String;
+	public final fun getSourceWindow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class codes/yousef/summon/desktop/communication/DragData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/communication/DragData$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcodes/yousef/summon/desktop/communication/DragData;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcodes/yousef/summon/desktop/communication/DragData;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class codes/yousef/summon/desktop/communication/DragEventListener {
+	public abstract fun onDragEnd (Ljava/lang/String;Z)V
+	public abstract fun onDragMove (Ljava/lang/String;DD)V
+	public abstract fun onDragStart (Lcodes/yousef/summon/desktop/communication/DragData;)V
+	public abstract fun onDropAccepted (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public abstract class codes/yousef/summon/desktop/communication/DragMessage {
+	public static final field Companion Lcodes/yousef/summon/desktop/communication/DragMessage$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Lcodes/yousef/summon/desktop/communication/DragMessage;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DragEnd : codes/yousef/summon/desktop/communication/DragMessage {
+	public static final field Companion Lcodes/yousef/summon/desktop/communication/DragMessage$DragEnd$Companion;
+	public fun <init> (Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lcodes/yousef/summon/desktop/communication/DragMessage$DragEnd;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/communication/DragMessage$DragEnd;Ljava/lang/String;ZILjava/lang/Object;)Lcodes/yousef/summon/desktop/communication/DragMessage$DragEnd;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCancelled ()Z
+	public final fun getDragId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class codes/yousef/summon/desktop/communication/DragMessage$DragEnd$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/communication/DragMessage$DragEnd$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcodes/yousef/summon/desktop/communication/DragMessage$DragEnd;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcodes/yousef/summon/desktop/communication/DragMessage$DragEnd;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DragEnd$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DragMove : codes/yousef/summon/desktop/communication/DragMessage {
+	public static final field Companion Lcodes/yousef/summon/desktop/communication/DragMessage$DragMove$Companion;
+	public fun <init> (Ljava/lang/String;DD)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun copy (Ljava/lang/String;DD)Lcodes/yousef/summon/desktop/communication/DragMessage$DragMove;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/communication/DragMessage$DragMove;Ljava/lang/String;DDILjava/lang/Object;)Lcodes/yousef/summon/desktop/communication/DragMessage$DragMove;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDragId ()Ljava/lang/String;
+	public final fun getX ()D
+	public final fun getY ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class codes/yousef/summon/desktop/communication/DragMessage$DragMove$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/communication/DragMessage$DragMove$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcodes/yousef/summon/desktop/communication/DragMessage$DragMove;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcodes/yousef/summon/desktop/communication/DragMessage$DragMove;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DragMove$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DragStart : codes/yousef/summon/desktop/communication/DragMessage {
+	public static final field Companion Lcodes/yousef/summon/desktop/communication/DragMessage$DragStart$Companion;
+	public fun <init> (Lcodes/yousef/summon/desktop/communication/DragData;)V
+	public final fun component1 ()Lcodes/yousef/summon/desktop/communication/DragData;
+	public final fun copy (Lcodes/yousef/summon/desktop/communication/DragData;)Lcodes/yousef/summon/desktop/communication/DragMessage$DragStart;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/communication/DragMessage$DragStart;Lcodes/yousef/summon/desktop/communication/DragData;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/communication/DragMessage$DragStart;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lcodes/yousef/summon/desktop/communication/DragData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class codes/yousef/summon/desktop/communication/DragMessage$DragStart$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/communication/DragMessage$DragStart$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcodes/yousef/summon/desktop/communication/DragMessage$DragStart;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcodes/yousef/summon/desktop/communication/DragMessage$DragStart;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DragStart$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DropAccepted : codes/yousef/summon/desktop/communication/DragMessage {
+	public static final field Companion Lcodes/yousef/summon/desktop/communication/DragMessage$DropAccepted$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/desktop/communication/DragMessage$DropAccepted;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/communication/DragMessage$DropAccepted;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/communication/DragMessage$DropAccepted;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDragId ()Ljava/lang/String;
+	public final fun getTargetWindow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class codes/yousef/summon/desktop/communication/DragMessage$DropAccepted$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/communication/DragMessage$DropAccepted$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcodes/yousef/summon/desktop/communication/DragMessage$DropAccepted;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcodes/yousef/summon/desktop/communication/DragMessage$DropAccepted;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class codes/yousef/summon/desktop/communication/DragMessage$DropAccepted$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class codes/yousef/summon/desktop/communication/SummonBroadcastChannel {
+	public abstract fun close ()V
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun isOpen ()Z
+	public abstract fun onMessage (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public abstract fun postMessage (Ljava/lang/Object;)V
+}
+
+public abstract interface class codes/yousef/summon/desktop/dialog/DirectoryHandle {
+	public abstract fun getFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun listFiles (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class codes/yousef/summon/desktop/dialog/FileDialogJvm {
+	public static final fun isFileSystemAccessSupported ()Z
+	public static final fun showDirectoryPicker (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun showDirectoryPicker$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun showOpenFileDialog (Lcodes/yousef/summon/desktop/dialog/FileDialogOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun showOpenFileDialog$default (Lcodes/yousef/summon/desktop/dialog/FileDialogOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun showSaveFileDialog (Lcodes/yousef/summon/desktop/dialog/SaveDialogOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun showSaveFileDialog$default (Lcodes/yousef/summon/desktop/dialog/SaveDialogOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class codes/yousef/summon/desktop/dialog/FileDialogOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/desktop/dialog/FileDialogOptions;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/dialog/FileDialogOptions;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/dialog/FileDialogOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMultiple ()Z
+	public final fun getStartIn ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/dialog/FileTypeFilter {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lcodes/yousef/summon/desktop/dialog/FileTypeFilter;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/dialog/FileTypeFilter;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/dialog/FileTypeFilter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccept ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/dialog/SaveDialogOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/desktop/dialog/SaveDialogOptions;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/dialog/SaveDialogOptions;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/dialog/SaveDialogOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStartIn ()Ljava/lang/String;
+	public final fun getSuggestedName ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/dialog/SaveDialogResult {
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lcodes/yousef/summon/desktop/dialog/SaveDialogResult;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/dialog/SaveDialogResult;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/dialog/SaveDialogResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getWrite ()Lkotlin/jvm/functions/Function2;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/menu/KeyboardShortcut {
+	public fun <init> (Ljava/lang/String;ZZZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;ZZZZ)Lcodes/yousef/summon/desktop/menu/KeyboardShortcut;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/menu/KeyboardShortcut;Ljava/lang/String;ZZZZILjava/lang/Object;)Lcodes/yousef/summon/desktop/menu/KeyboardShortcut;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlt ()Z
+	public final fun getCtrl ()Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getMeta ()Z
+	public final fun getShift ()Z
+	public fun hashCode ()I
+	public final fun toDisplayString ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/menu/Menu {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Z)Lcodes/yousef/summon/desktop/menu/Menu;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/menu/Menu;Ljava/lang/String;Ljava/util/List;ZILjava/lang/Object;)Lcodes/yousef/summon/desktop/menu/Menu;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisabled ()Z
+	public final fun getItems ()Ljava/util/List;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/menu/MenuBarBuilder {
+	public fun <init> ()V
+	public final fun menu (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun menu$default (Lcodes/yousef/summon/desktop/menu/MenuBarBuilder;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/desktop/menu/MenuBarKt {
+	public static final fun MenuBar (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)V
+	public static final fun MenuBar (Ljava/util/List;Lcodes/yousef/summon/modifier/Modifier;)V
+	public static synthetic fun MenuBar$default (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun MenuBar$default (Ljava/util/List;Lcodes/yousef/summon/modifier/Modifier;ILjava/lang/Object;)V
+	public static final fun menuBar (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class codes/yousef/summon/desktop/menu/MenuBuilder {
+	public fun <init> ()V
+	public final fun item (Ljava/lang/String;Lcodes/yousef/summon/desktop/menu/KeyboardShortcut;Ljava/lang/String;ZLjava/lang/Boolean;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun item$default (Lcodes/yousef/summon/desktop/menu/MenuBuilder;Ljava/lang/String;Lcodes/yousef/summon/desktop/menu/KeyboardShortcut;Ljava/lang/String;ZLjava/lang/Boolean;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun separator ()V
+	public final fun submenu (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun submenu$default (Lcodes/yousef/summon/desktop/menu/MenuBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/desktop/menu/MenuItem {
+	public static final field Companion Lcodes/yousef/summon/desktop/menu/MenuItem$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ZLcodes/yousef/summon/desktop/menu/KeyboardShortcut;Ljava/lang/String;Ljava/util/List;ZLjava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ZLcodes/yousef/summon/desktop/menu/KeyboardShortcut;Ljava/lang/String;Ljava/util/List;ZLjava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function0;
+	public final fun component3 ()Z
+	public final fun component4 ()Lcodes/yousef/summon/desktop/menu/KeyboardShortcut;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ZLcodes/yousef/summon/desktop/menu/KeyboardShortcut;Ljava/lang/String;Ljava/util/List;ZLjava/lang/Boolean;)Lcodes/yousef/summon/desktop/menu/MenuItem;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/menu/MenuItem;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ZLcodes/yousef/summon/desktop/menu/KeyboardShortcut;Ljava/lang/String;Ljava/util/List;ZLjava/lang/Boolean;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/menu/MenuItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChecked ()Ljava/lang/Boolean;
+	public final fun getDisabled ()Z
+	public final fun getIcon ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getOnClick ()Lkotlin/jvm/functions/Function0;
+	public final fun getShortcut ()Lcodes/yousef/summon/desktop/menu/KeyboardShortcut;
+	public final fun getSubmenu ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isSeparator ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/menu/MenuItem$Companion {
+	public final fun separator ()Lcodes/yousef/summon/desktop/menu/MenuItem;
+}
+
+public final class codes/yousef/summon/desktop/pip/PictureInPictureJvm {
+	public static final fun PictureInPictureContent (Lcodes/yousef/summon/desktop/pip/PipWindow;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun PictureInPictureContent$default (Lcodes/yousef/summon/desktop/pip/PipWindow;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun isPictureInPictureSupported ()Z
+	public static final fun requestPictureInPicture (Lcodes/yousef/summon/desktop/pip/PipOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun requestPictureInPicture$default (Lcodes/yousef/summon/desktop/pip/PipOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class codes/yousef/summon/desktop/pip/PipOptions {
+	public fun <init> ()V
+	public fun <init> (IIZ)V
+	public synthetic fun <init> (IIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Z
+	public final fun copy (IIZ)Lcodes/yousef/summon/desktop/pip/PipOptions;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/pip/PipOptions;IIZILjava/lang/Object;)Lcodes/yousef/summon/desktop/pip/PipOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCopyStyleSheets ()Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class codes/yousef/summon/desktop/pip/PipResult {
+}
+
+public final class codes/yousef/summon/desktop/pip/PipResult$Error : codes/yousef/summon/desktop/pip/PipResult {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcodes/yousef/summon/desktop/pip/PipResult$Error;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/pip/PipResult$Error;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/pip/PipResult$Error;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/pip/PipResult$NotSupported : codes/yousef/summon/desktop/pip/PipResult {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/pip/PipResult$NotSupported;
+}
+
+public final class codes/yousef/summon/desktop/pip/PipResult$Success : codes/yousef/summon/desktop/pip/PipResult {
+	public fun <init> (Lcodes/yousef/summon/desktop/pip/PipWindow;)V
+	public final fun component1 ()Lcodes/yousef/summon/desktop/pip/PipWindow;
+	public final fun copy (Lcodes/yousef/summon/desktop/pip/PipWindow;)Lcodes/yousef/summon/desktop/pip/PipResult$Success;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/pip/PipResult$Success;Lcodes/yousef/summon/desktop/pip/PipWindow;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/pip/PipResult$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWindow ()Lcodes/yousef/summon/desktop/pip/PipWindow;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/pip/PipResult$UserDenied : codes/yousef/summon/desktop/pip/PipResult {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/pip/PipResult$UserDenied;
+}
+
+public abstract interface class codes/yousef/summon/desktop/pip/PipWindow {
+	public abstract fun close ()V
+	public abstract fun focus ()V
+	public abstract fun getHeight ()I
+	public abstract fun getWidth ()I
+	public abstract fun isOpen ()Z
+}
+
+public abstract interface class codes/yousef/summon/desktop/storage/SyncedStorage {
+	public abstract fun addChangeListener (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public abstract fun clear ()V
+	public abstract fun exists ()Z
+	public abstract fun getValue ()Ljava/lang/Object;
+	public abstract fun setValue (Ljava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/desktop/storage/SyncedStorageJvm {
+	public static final fun createSyncedStorage (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+}
+
+public final class codes/yousef/summon/desktop/storage/SyncedStorageKt {
+	public static final fun createSyncedBooleanStorage (Ljava/lang/String;Z)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun createSyncedBooleanStorage$default (Ljava/lang/String;ZILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun createSyncedDoubleStorage (Ljava/lang/String;D)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun createSyncedDoubleStorage$default (Ljava/lang/String;DILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun createSyncedIntStorage (Ljava/lang/String;I)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun createSyncedIntStorage$default (Ljava/lang/String;IILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun createSyncedLongStorage (Ljava/lang/String;J)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun createSyncedLongStorage$default (Ljava/lang/String;JILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun createSyncedStringStorage (Ljava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun createSyncedStringStorage$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun rememberSynced (Ljava/lang/String;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun rememberSyncedBoolean (Ljava/lang/String;Z)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun rememberSyncedBoolean$default (Ljava/lang/String;ZILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun rememberSyncedInt (Ljava/lang/String;I)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun rememberSyncedInt$default (Ljava/lang/String;IILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static final fun rememberSyncedString (Ljava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+	public static synthetic fun rememberSyncedString$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/storage/SyncedStorage;
+}
+
+public abstract class codes/yousef/summon/desktop/tray/NotificationResult {
+}
+
+public final class codes/yousef/summon/desktop/tray/NotificationResult$Error : codes/yousef/summon/desktop/tray/NotificationResult {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcodes/yousef/summon/desktop/tray/NotificationResult$Error;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/tray/NotificationResult$Error;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/tray/NotificationResult$Error;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/tray/NotificationResult$NotSupported : codes/yousef/summon/desktop/tray/NotificationResult {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/tray/NotificationResult$NotSupported;
+}
+
+public final class codes/yousef/summon/desktop/tray/NotificationResult$PermissionDenied : codes/yousef/summon/desktop/tray/NotificationResult {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/tray/NotificationResult$PermissionDenied;
+}
+
+public final class codes/yousef/summon/desktop/tray/NotificationResult$Success : codes/yousef/summon/desktop/tray/NotificationResult {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/tray/NotificationResult$Success;
+}
+
+public final class codes/yousef/summon/desktop/tray/SystemTrayJvm {
+	public static final fun createTrayIcon (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Ljava/util/List;)Lcodes/yousef/summon/desktop/tray/TrayIcon;
+	public static synthetic fun createTrayIcon$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Ljava/util/List;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/tray/TrayIcon;
+	public static final fun isSystemTraySupported ()Z
+	public static final fun showNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun showNotification$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class codes/yousef/summon/desktop/tray/TrayIcon {
+	public abstract fun getIconUrl ()Ljava/lang/String;
+	public abstract fun getTooltip ()Ljava/lang/String;
+	public abstract fun remove ()V
+	public abstract fun setIcon (Ljava/lang/String;)V
+	public abstract fun setMenu (Ljava/util/List;)V
+	public abstract fun setTooltip (Ljava/lang/String;)V
+}
+
+public final class codes/yousef/summon/desktop/window/ScreenInfo {
+	public fun <init> (IIIIIID)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()D
+	public final fun copy (IIIIIID)Lcodes/yousef/summon/desktop/window/ScreenInfo;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/window/ScreenInfo;IIIIIIDILjava/lang/Object;)Lcodes/yousef/summon/desktop/window/ScreenInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailHeight ()I
+	public final fun getAvailWidth ()I
+	public final fun getColorDepth ()I
+	public final fun getDevicePixelRatio ()D
+	public final fun getHeight ()I
+	public final fun getPixelDepth ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/desktop/window/WindowManager {
+	public static final field INSTANCE Lcodes/yousef/summon/desktop/window/WindowManager;
+	public final fun arePopupsLikelyBlocked ()Z
+	public final fun focus ()V
+	public final fun getCurrentWindowBounds ()Lkotlin/Pair;
+	public final fun getCurrentWindowId ()Ljava/lang/String;
+	public final fun getScreenInfo ()Lcodes/yousef/summon/desktop/window/ScreenInfo;
+	public final fun moveTo (II)V
+	public final fun open (Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/desktop/window/WindowOptions;)Lcodes/yousef/summon/desktop/window/WindowReference;
+	public static synthetic fun open$default (Lcodes/yousef/summon/desktop/window/WindowManager;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/desktop/window/WindowOptions;ILjava/lang/Object;)Lcodes/yousef/summon/desktop/window/WindowReference;
+	public final fun resizeTo (II)V
+}
+
+public final class codes/yousef/summon/desktop/window/WindowOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ZZZZZZ)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ZZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ZZZZZZ)Lcodes/yousef/summon/desktop/window/WindowOptions;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/desktop/window/WindowOptions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ZZZZZZILjava/lang/Object;)Lcodes/yousef/summon/desktop/window/WindowOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getLeft ()Ljava/lang/Integer;
+	public final fun getLocation ()Z
+	public final fun getMenubar ()Z
+	public final fun getResizable ()Z
+	public final fun getScrollbars ()Z
+	public final fun getStatus ()Z
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getToolbar ()Z
+	public final fun getTop ()Ljava/lang/Integer;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class codes/yousef/summon/desktop/window/WindowReference {
+	public abstract fun close ()V
+	public abstract fun focus ()V
+	public abstract fun getLocation ()Ljava/lang/String;
+	public abstract fun isClosed ()Z
+	public abstract fun navigate (Ljava/lang/String;)V
+	public abstract fun postMessage (Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun postMessage$default (Lcodes/yousef/summon/desktop/window/WindowReference;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+}
+
+public final class codes/yousef/summon/desktop/window/WindowReference$DefaultImpls {
+	public static synthetic fun postMessage$default (Lcodes/yousef/summon/desktop/window/WindowReference;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract interface class codes/yousef/summon/effects/ClipboardAPI {
@@ -5586,6 +6702,16 @@ public final class codes/yousef/summon/modifier/AutoMarginModifiersKt {
 	public static final fun marginVerticalAutoZero (Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
 }
 
+public final class codes/yousef/summon/modifier/BackgroundAttachment : java/lang/Enum {
+	public static final field Fixed Lcodes/yousef/summon/modifier/BackgroundAttachment;
+	public static final field Local Lcodes/yousef/summon/modifier/BackgroundAttachment;
+	public static final field Scroll Lcodes/yousef/summon/modifier/BackgroundAttachment;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/BackgroundAttachment;
+	public static fun values ()[Lcodes/yousef/summon/modifier/BackgroundAttachment;
+}
+
 public final class codes/yousef/summon/modifier/BackgroundClip : java/lang/Enum {
 	public static final field BorderBox Lcodes/yousef/summon/modifier/BackgroundClip;
 	public static final field ContentBox Lcodes/yousef/summon/modifier/BackgroundClip;
@@ -5601,6 +6727,7 @@ public final class codes/yousef/summon/modifier/BackgroundClip : java/lang/Enum 
 public final class codes/yousef/summon/modifier/BackgroundModifiersKt {
 	public static final fun background (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
 	public static synthetic fun background$default (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun backgroundAttachment (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/BackgroundAttachment;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun backgroundClip (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/BackgroundClip;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun backgroundClip (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun backgroundClipText (Lcodes/yousef/summon/modifier/Modifier;Z)Lcodes/yousef/summon/modifier/Modifier;
@@ -5670,6 +6797,7 @@ public final class codes/yousef/summon/modifier/BlendMode : java/lang/Enum {
 }
 
 public final class codes/yousef/summon/modifier/BorderModifiersKt {
+	public static final fun border (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/BorderSide;Ljava/lang/Number;Lcodes/yousef/summon/modifier/BorderStyle;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun border (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
 	public static synthetic fun border$default (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun borderBottomWidth (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
@@ -5760,6 +6888,16 @@ public final class codes/yousef/summon/modifier/BoxShadowModifiersKt {
 	public static synthetic fun shadowConfig$default (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;ZILjava/lang/Object;)Lcodes/yousef/summon/modifier/ShadowConfig;
 }
 
+public final class codes/yousef/summon/modifier/BoxSizing : java/lang/Enum {
+	public static final field BorderBox Lcodes/yousef/summon/modifier/BoxSizing;
+	public static final field ContentBox Lcodes/yousef/summon/modifier/BoxSizing;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/BoxSizing;
+	public static fun values ()[Lcodes/yousef/summon/modifier/BoxSizing;
+}
+
 public final class codes/yousef/summon/modifier/Breakpoints {
 	public static final field INSTANCE Lcodes/yousef/summon/modifier/Breakpoints;
 	public final fun getLG ()I
@@ -5805,6 +6943,43 @@ public final class codes/yousef/summon/modifier/ClipPathModifiersKt {
 	public static final fun clipTriangleLeft (Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun clipTriangleRight (Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun clipTriangleUp (Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
+}
+
+public final class codes/yousef/summon/modifier/ColorScheme : java/lang/Enum {
+	public static final field Dark Lcodes/yousef/summon/modifier/ColorScheme;
+	public static final field DarkLight Lcodes/yousef/summon/modifier/ColorScheme;
+	public static final field Light Lcodes/yousef/summon/modifier/ColorScheme;
+	public static final field LightDark Lcodes/yousef/summon/modifier/ColorScheme;
+	public static final field Normal Lcodes/yousef/summon/modifier/ColorScheme;
+	public static final field OnlyDark Lcodes/yousef/summon/modifier/ColorScheme;
+	public static final field OnlyLight Lcodes/yousef/summon/modifier/ColorScheme;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/ColorScheme;
+	public static fun values ()[Lcodes/yousef/summon/modifier/ColorScheme;
+}
+
+public abstract interface class codes/yousef/summon/modifier/ConditionalStyleDefinition {
+	public abstract fun getStyles ()Ljava/util/Map;
+}
+
+public final class codes/yousef/summon/modifier/ConditionalStyleState : java/lang/Enum {
+	public static final field ACTIVE Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field CHECKED Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field DISABLED Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field FIRST_CHILD Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field FOCUS Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field FOCUS_VISIBLE Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field FOCUS_WITHIN Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field HOVER Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field LAST_CHILD Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field NTH_CHILD Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field ONLY_CHILD Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static final field VISITED Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public static fun values ()[Lcodes/yousef/summon/modifier/ConditionalStyleState;
 }
 
 public final class codes/yousef/summon/modifier/ConicGradientBuilder {
@@ -6066,6 +7241,17 @@ public final class codes/yousef/summon/modifier/GradientPresets {
 	public final fun warmSunset (Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
 }
 
+public final class codes/yousef/summon/modifier/GridTrack {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/modifier/GridTrack;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/GridTrack;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class codes/yousef/summon/modifier/JustifyContent : java/lang/Enum {
 	public static final field Center Lcodes/yousef/summon/modifier/JustifyContent;
 	public static final field FlexEnd Lcodes/yousef/summon/modifier/JustifyContent;
@@ -6184,6 +7370,26 @@ public final class codes/yousef/summon/modifier/LinearGradientBuilder {
 	public static synthetic fun colorStop$default (Lcodes/yousef/summon/modifier/LinearGradientBuilder;Lcodes/yousef/summon/core/style/Color;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun colorStop$default (Lcodes/yousef/summon/modifier/LinearGradientBuilder;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun direction (Ljava/lang/String;)V
+}
+
+public final class codes/yousef/summon/modifier/ListStyleType : java/lang/Enum {
+	public static final field Circle Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field Decimal Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field DecimalLeadingZero Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field Disc Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field DisclosureClosed Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field DisclosureOpen Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field LowerAlpha Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field LowerRoman Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field None Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field Square Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field UpperAlpha Lcodes/yousef/summon/modifier/ListStyleType;
+	public static final field UpperRoman Lcodes/yousef/summon/modifier/ListStyleType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/ListStyleType;
+	public static fun values ()[Lcodes/yousef/summon/modifier/ListStyleType;
 }
 
 public final class codes/yousef/summon/modifier/MediaModifiersKt {
@@ -6324,13 +7530,43 @@ public final class codes/yousef/summon/modifier/MediaQuery$PrefersReducedMotion 
 }
 
 public final class codes/yousef/summon/modifier/MediaQueryModifiersKt {
+	public static final fun breakpointBetween (Lcodes/yousef/summon/modifier/Modifier;IILkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun lg (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun lgDown (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun lgOnly (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun md (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun mdDown (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun mdOnly (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun mediaQuery (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/MediaQuery;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun sm (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun smDown (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun smOnly (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun xl (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun xlDown (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun xlOnly (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun xs (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun xxl (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun xxlDown (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+}
+
+public final class codes/yousef/summon/modifier/MediaStyleDefinition : codes/yousef/summon/modifier/ConditionalStyleDefinition {
+	public fun <init> (Lcodes/yousef/summon/modifier/MediaQuery;Ljava/util/Map;)V
+	public final fun component1 ()Lcodes/yousef/summon/modifier/MediaQuery;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Lcodes/yousef/summon/modifier/MediaQuery;Ljava/util/Map;)Lcodes/yousef/summon/modifier/MediaStyleDefinition;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/modifier/MediaStyleDefinition;Lcodes/yousef/summon/modifier/MediaQuery;Ljava/util/Map;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/MediaStyleDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQuery ()Lcodes/yousef/summon/modifier/MediaQuery;
+	public fun getStyles ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class codes/yousef/summon/modifier/Modifier {
 	public static final field Companion Lcodes/yousef/summon/modifier/Modifier$Companion;
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getComplexEventHandlers ()Ljava/util/Map;
+	public fun getConditionalStyles ()Ljava/util/List;
 	public fun getEventHandlers ()Ljava/util/Map;
 	public fun getPseudoElements ()Ljava/util/List;
 	public fun getStyles ()Ljava/util/Map;
@@ -6340,6 +7576,7 @@ public abstract interface class codes/yousef/summon/modifier/Modifier {
 public final class codes/yousef/summon/modifier/Modifier$Companion : codes/yousef/summon/modifier/Modifier {
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getComplexEventHandlers ()Ljava/util/Map;
+	public fun getConditionalStyles ()Ljava/util/List;
 	public fun getEventHandlers ()Ljava/util/Map;
 	public fun getPseudoElements ()Ljava/util/List;
 	public fun getStyles ()Ljava/util/Map;
@@ -6350,6 +7587,7 @@ public final class codes/yousef/summon/modifier/Modifier$Companion : codes/youse
 public final class codes/yousef/summon/modifier/Modifier$DefaultImpls {
 	public static fun getAttributes (Lcodes/yousef/summon/modifier/Modifier;)Ljava/util/Map;
 	public static fun getComplexEventHandlers (Lcodes/yousef/summon/modifier/Modifier;)Ljava/util/Map;
+	public static fun getConditionalStyles (Lcodes/yousef/summon/modifier/Modifier;)Ljava/util/List;
 	public static fun getEventHandlers (Lcodes/yousef/summon/modifier/Modifier;)Ljava/util/Map;
 	public static fun getPseudoElements (Lcodes/yousef/summon/modifier/Modifier;)Ljava/util/List;
 	public static fun getStyles (Lcodes/yousef/summon/modifier/Modifier;)Ljava/util/Map;
@@ -6393,18 +7631,20 @@ public final class codes/yousef/summon/modifier/ModifierExtras {
 
 public final class codes/yousef/summon/modifier/ModifierImpl : codes/yousef/summon/modifier/Modifier {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Map;
 	public final fun component2 ()Ljava/util/Map;
 	public final fun component3 ()Ljava/util/Map;
 	public final fun component4 ()Ljava/util/Map;
 	public final fun component5 ()Ljava/util/List;
-	public final fun copy (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;)Lcodes/yousef/summon/modifier/ModifierImpl;
-	public static synthetic fun copy$default (Lcodes/yousef/summon/modifier/ModifierImpl;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/ModifierImpl;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/util/List;)Lcodes/yousef/summon/modifier/ModifierImpl;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/modifier/ModifierImpl;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/ModifierImpl;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getComplexEventHandlers ()Ljava/util/Map;
+	public fun getConditionalStyles ()Ljava/util/List;
 	public fun getEventHandlers ()Ljava/util/Map;
 	public fun getPseudoElements ()Ljava/util/List;
 	public fun getStyles ()Ljava/util/Map;
@@ -6414,8 +7654,8 @@ public final class codes/yousef/summon/modifier/ModifierImpl : codes/yousef/summ
 }
 
 public final class codes/yousef/summon/modifier/ModifierKt {
-	public static final fun Modifier (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;)Lcodes/yousef/summon/modifier/Modifier;
-	public static synthetic fun Modifier$default (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun Modifier (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/util/List;)Lcodes/yousef/summon/modifier/Modifier;
+	public static synthetic fun Modifier$default (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun absolutePosition (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
 	public static synthetic fun absolutePosition$default (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun addClass (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
@@ -6496,6 +7736,24 @@ public final class codes/yousef/summon/modifier/ObjectFit : java/lang/Enum {
 	public static fun values ()[Lcodes/yousef/summon/modifier/ObjectFit;
 }
 
+public final class codes/yousef/summon/modifier/OutlineStyle : java/lang/Enum {
+	public static final field Auto Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Dashed Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Dotted Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Double Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Groove Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Inset Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field None Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Outset Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Ridge Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static final field Solid Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/OutlineStyle;
+	public static fun values ()[Lcodes/yousef/summon/modifier/OutlineStyle;
+}
+
 public final class codes/yousef/summon/modifier/Overflow : java/lang/Enum {
 	public static final field Auto Lcodes/yousef/summon/modifier/Overflow;
 	public static final field Hidden Lcodes/yousef/summon/modifier/Overflow;
@@ -6506,6 +7764,17 @@ public final class codes/yousef/summon/modifier/Overflow : java/lang/Enum {
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/Overflow;
 	public static fun values ()[Lcodes/yousef/summon/modifier/Overflow;
+}
+
+public final class codes/yousef/summon/modifier/OverflowWrap : java/lang/Enum {
+	public static final field Anywhere Lcodes/yousef/summon/modifier/OverflowWrap;
+	public static final field BreakWord Lcodes/yousef/summon/modifier/OverflowWrap;
+	public static final field Normal Lcodes/yousef/summon/modifier/OverflowWrap;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/OverflowWrap;
+	public static fun values ()[Lcodes/yousef/summon/modifier/OverflowWrap;
 }
 
 public final class codes/yousef/summon/modifier/PointerEventModifiersKt {
@@ -6697,6 +7966,35 @@ public final class codes/yousef/summon/modifier/RowColumnModifiersKt {
 	public static final fun verticalAlignment (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/components/layout/Alignment$Vertical;)Lcodes/yousef/summon/modifier/Modifier;
 }
 
+public final class codes/yousef/summon/modifier/ScopedStyleDefinition : codes/yousef/summon/modifier/ConditionalStyleDefinition {
+	public fun <init> (Ljava/lang/String;Lcodes/yousef/summon/modifier/SelectorType;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcodes/yousef/summon/modifier/SelectorType;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lcodes/yousef/summon/modifier/SelectorType;Ljava/util/Map;)Lcodes/yousef/summon/modifier/ScopedStyleDefinition;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/modifier/ScopedStyleDefinition;Ljava/lang/String;Lcodes/yousef/summon/modifier/SelectorType;Ljava/util/Map;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/ScopedStyleDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSelector ()Ljava/lang/String;
+	public final fun getSelectorType ()Lcodes/yousef/summon/modifier/SelectorType;
+	public fun getStyles ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/modifier/ScopedStyleModifiersKt {
+	public static final fun adjacentSibling (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun child (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun classStyle (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun descendant (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun firstChildStyle (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun generalSibling (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun headingStyle (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun lastChildStyle (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun linkStyle (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun listItemStyle (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun paragraphStyle (Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function1;)Lcodes/yousef/summon/modifier/Modifier;
+}
+
 public final class codes/yousef/summon/modifier/ScrollBehavior : java/lang/Enum {
 	public static final field AUTO Lcodes/yousef/summon/modifier/ScrollBehavior;
 	public static final field SMOOTH Lcodes/yousef/summon/modifier/ScrollBehavior;
@@ -6740,6 +8038,28 @@ public final class codes/yousef/summon/modifier/ScrollSnapType : java/lang/Enum 
 	public static fun values ()[Lcodes/yousef/summon/modifier/ScrollSnapType;
 }
 
+public final class codes/yousef/summon/modifier/ScrollbarWidth : java/lang/Enum {
+	public static final field Auto Lcodes/yousef/summon/modifier/ScrollbarWidth;
+	public static final field None Lcodes/yousef/summon/modifier/ScrollbarWidth;
+	public static final field Thin Lcodes/yousef/summon/modifier/ScrollbarWidth;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/ScrollbarWidth;
+	public static fun values ()[Lcodes/yousef/summon/modifier/ScrollbarWidth;
+}
+
+public final class codes/yousef/summon/modifier/SelectorType : java/lang/Enum {
+	public static final field ADJACENT Lcodes/yousef/summon/modifier/SelectorType;
+	public static final field CHILD Lcodes/yousef/summon/modifier/SelectorType;
+	public static final field DESCENDANT Lcodes/yousef/summon/modifier/SelectorType;
+	public static final field GENERAL_SIBLING Lcodes/yousef/summon/modifier/SelectorType;
+	public final fun getCombinator ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/SelectorType;
+	public static fun values ()[Lcodes/yousef/summon/modifier/SelectorType;
+}
+
 public final class codes/yousef/summon/modifier/ShadowConfig {
 	public static final field Companion Lcodes/yousef/summon/modifier/ShadowConfig$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/core/style/Color;Z)V
@@ -6770,6 +8090,22 @@ public final class codes/yousef/summon/modifier/ShadowConfig$Companion {
 	public final fun glow (Ljava/lang/Number;Lcodes/yousef/summon/core/style/Color;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/ShadowConfig;
 	public static synthetic fun glow$default (Lcodes/yousef/summon/modifier/ShadowConfig$Companion;Ljava/lang/Number;Lcodes/yousef/summon/core/style/Color;Ljava/lang/Number;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/ShadowConfig;
 	public final fun innerGlow (Ljava/lang/Number;Lcodes/yousef/summon/core/style/Color;)Lcodes/yousef/summon/modifier/ShadowConfig;
+}
+
+public final class codes/yousef/summon/modifier/StateStyleDefinition : codes/yousef/summon/modifier/ConditionalStyleDefinition {
+	public fun <init> (Lcodes/yousef/summon/modifier/ConditionalStyleState;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcodes/yousef/summon/modifier/ConditionalStyleState;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcodes/yousef/summon/modifier/ConditionalStyleState;Ljava/util/Map;Ljava/lang/String;)Lcodes/yousef/summon/modifier/StateStyleDefinition;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/modifier/StateStyleDefinition;Lcodes/yousef/summon/modifier/ConditionalStyleState;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/StateStyleDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgument ()Ljava/lang/String;
+	public final fun getState ()Lcodes/yousef/summon/modifier/ConditionalStyleState;
+	public fun getStyles ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class codes/yousef/summon/modifier/StylingModifiersKt {
@@ -6816,6 +8152,40 @@ public final class codes/yousef/summon/modifier/TextDecoration : java/lang/Enum 
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/TextDecoration;
 	public static fun values ()[Lcodes/yousef/summon/modifier/TextDecoration;
+}
+
+public final class codes/yousef/summon/modifier/TextOverflow : java/lang/Enum {
+	public static final field Clip Lcodes/yousef/summon/modifier/TextOverflow;
+	public static final field Ellipsis Lcodes/yousef/summon/modifier/TextOverflow;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/TextOverflow;
+	public static fun values ()[Lcodes/yousef/summon/modifier/TextOverflow;
+}
+
+public final class codes/yousef/summon/modifier/TextShadow {
+	public static final field Companion Lcodes/yousef/summon/modifier/TextShadow$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcodes/yousef/summon/modifier/TextShadow;
+	public static synthetic fun copy$default (Lcodes/yousef/summon/modifier/TextShadow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/TextShadow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlurRadius ()Ljava/lang/String;
+	public final fun getColor ()Ljava/lang/String;
+	public final fun getOffsetX ()Ljava/lang/String;
+	public final fun getOffsetY ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class codes/yousef/summon/modifier/TextShadow$Companion {
+	public final fun pixels (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcodes/yousef/summon/core/style/Color;)Lcodes/yousef/summon/modifier/TextShadow;
+	public static synthetic fun pixels$default (Lcodes/yousef/summon/modifier/TextShadow$Companion;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcodes/yousef/summon/core/style/Color;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/TextShadow;
 }
 
 public final class codes/yousef/summon/modifier/TextTransform : java/lang/Enum {
@@ -6879,6 +8249,8 @@ public final class codes/yousef/summon/modifier/TransitionModifiersKt {
 	public static final fun firstChild (Lcodes/yousef/summon/modifier/Modifier;Ljava/util/Map;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun focus (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun focus (Lcodes/yousef/summon/modifier/Modifier;Ljava/util/Map;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun focusVisible (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun focusVisible (Lcodes/yousef/summon/modifier/Modifier;Ljava/util/Map;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun focusWithin (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun focusWithin (Lcodes/yousef/summon/modifier/Modifier;Ljava/util/Map;)Lcodes/yousef/summon/modifier/Modifier;
 	public static final fun hover (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/Modifier;)Lcodes/yousef/summon/modifier/Modifier;
@@ -6954,6 +8326,59 @@ public final class codes/yousef/summon/modifier/TransitionTimingFunction : java/
 	public static fun values ()[Lcodes/yousef/summon/modifier/TransitionTimingFunction;
 }
 
+public final class codes/yousef/summon/modifier/TypedCssModifiersKt {
+	public static final fun boxSizing (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/BoxSizing;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun boxSizing (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun colorScheme (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/ColorScheme;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun colorScheme (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun direction (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/i18n/LayoutDirection;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun gridAutoFill ([Lcodes/yousef/summon/modifier/GridTrack;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static final fun gridAutoFit ([Lcodes/yousef/summon/modifier/GridTrack;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static final fun gridFraction (Ljava/lang/Number;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static synthetic fun gridFraction$default (Ljava/lang/Number;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static final fun gridMinMax (Lcodes/yousef/summon/modifier/GridTrack;Lcodes/yousef/summon/modifier/GridTrack;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static final fun gridRepeat (I[Lcodes/yousef/summon/modifier/GridTrack;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static final fun gridTemplateColumns (Lcodes/yousef/summon/modifier/Modifier;[Lcodes/yousef/summon/modifier/GridTrack;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun gridTemplateRows (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun gridTemplateRows (Lcodes/yousef/summon/modifier/Modifier;[Lcodes/yousef/summon/modifier/GridTrack;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun gridTrack (Ljava/lang/String;)Lcodes/yousef/summon/modifier/GridTrack;
+	public static final fun inset (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun inset (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun inset (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun insetInlineEnd (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun insetInlineEnd (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun insetInlineStart (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun insetInlineStart (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun lineClamp (Lcodes/yousef/summon/modifier/Modifier;IZ)Lcodes/yousef/summon/modifier/Modifier;
+	public static synthetic fun lineClamp$default (Lcodes/yousef/summon/modifier/Modifier;IZILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun listStyle (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/ListStyleType;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun listStyle (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun listStyleType (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/ListStyleType;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun listStyleType (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun outline (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;Lcodes/yousef/summon/modifier/OutlineStyle;Lcodes/yousef/summon/core/style/Color;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun outline (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;Lcodes/yousef/summon/modifier/OutlineStyle;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun outline (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun outline (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lcodes/yousef/summon/modifier/OutlineStyle;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun outlineOffset (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun outlineOffset (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun overflowWrap (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/OverflowWrap;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun overflowWrap (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun scrollbarColor (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/core/style/Color;Lcodes/yousef/summon/core/style/Color;Lcodes/yousef/summon/components/ScrollableComponent;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun scrollbarColor (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/components/ScrollableComponent;)Lcodes/yousef/summon/modifier/Modifier;
+	public static synthetic fun scrollbarColor$default (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/core/style/Color;Lcodes/yousef/summon/core/style/Color;Lcodes/yousef/summon/components/ScrollableComponent;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
+	public static synthetic fun scrollbarColor$default (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Ljava/lang/String;Lcodes/yousef/summon/components/ScrollableComponent;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun scrollbarWidth (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/ScrollbarWidth;Lcodes/yousef/summon/components/ScrollableComponent;)Lcodes/yousef/summon/modifier/Modifier;
+	public static synthetic fun scrollbarWidth$default (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/ScrollbarWidth;Lcodes/yousef/summon/components/ScrollableComponent;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun textOverflow (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/TextOverflow;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun textOverflow (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun textShadow (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun textShadow (Lcodes/yousef/summon/modifier/Modifier;[Lcodes/yousef/summon/modifier/TextShadow;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun textUnderlineOffset (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/Number;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun textUnderlineOffset (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun wordBreak (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/modifier/WordBreak;)Lcodes/yousef/summon/modifier/Modifier;
+	public static final fun wordBreak (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;)Lcodes/yousef/summon/modifier/Modifier;
+}
+
 public final class codes/yousef/summon/modifier/TypedModifiersKt {
 	public static final fun fontFamily (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lcodes/yousef/summon/components/TextComponent;)Lcodes/yousef/summon/modifier/Modifier;
 	public static synthetic fun fontFamily$default (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lcodes/yousef/summon/components/TextComponent;ILjava/lang/Object;)Lcodes/yousef/summon/modifier/Modifier;
@@ -7020,6 +8445,18 @@ public final class codes/yousef/summon/modifier/WhiteSpace : java/lang/Enum {
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/WhiteSpace;
 	public static fun values ()[Lcodes/yousef/summon/modifier/WhiteSpace;
+}
+
+public final class codes/yousef/summon/modifier/WordBreak : java/lang/Enum {
+	public static final field BreakAll Lcodes/yousef/summon/modifier/WordBreak;
+	public static final field BreakWord Lcodes/yousef/summon/modifier/WordBreak;
+	public static final field KeepAll Lcodes/yousef/summon/modifier/WordBreak;
+	public static final field Normal Lcodes/yousef/summon/modifier/WordBreak;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcodes/yousef/summon/modifier/WordBreak;
+	public static fun values ()[Lcodes/yousef/summon/modifier/WordBreak;
 }
 
 public final class codes/yousef/summon/platform/JvmPlatformRendererBridgeKt {
@@ -7907,6 +9344,7 @@ public class codes/yousef/summon/runtime/PlatformRenderer {
 	public fun renderLink (Lcodes/yousef/summon/modifier/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public fun renderLink (Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;)V
 	public fun renderLoading (Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/components/feedback/LoadingVariant;Lcodes/yousef/summon/components/feedback/LoadingSize;Ljava/lang/String;Lcodes/yousef/summon/modifier/Modifier;)V
+	public fun renderMenuBar (Ljava/util/List;Lcodes/yousef/summon/modifier/Modifier;)V
 	public fun renderModal (Lkotlin/jvm/functions/Function0;Lcodes/yousef/summon/modifier/Modifier;Lcodes/yousef/summon/components/feedback/ModalVariant;Lcodes/yousef/summon/components/feedback/ModalSize;ZZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
 	public fun renderModal (ZLkotlin/jvm/functions/Function0;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
 	public fun renderModalBottomSheet (Lkotlin/jvm/functions/Function0;Lcodes/yousef/summon/modifier/Modifier;Lkotlin/jvm/functions/Function0;)V
@@ -8032,6 +9470,11 @@ public final class codes/yousef/summon/runtime/StateKt {
 	public static final fun invoke (Lcodes/yousef/summon/state/State;)Ljava/lang/Object;
 	public static final fun invoke (Lcodes/yousef/summon/state/SummonMutableState;Ljava/lang/Object;)V
 	public static final fun mutableStateOf (Ljava/lang/Object;)Lcodes/yousef/summon/state/SummonMutableState;
+}
+
+public final class codes/yousef/summon/runtime/SummonConstants {
+	public static final field DEFAULT_ROOT_ELEMENT_ID Ljava/lang/String;
+	public static final field INSTANCE Lcodes/yousef/summon/runtime/SummonConstants;
 }
 
 public final class codes/yousef/summon/runtime/SummonLogger {

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/display/TextUtils.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/display/TextUtils.kt
@@ -187,7 +187,7 @@ fun SuccessText(text: String, modifier: Modifier = Modifier()) {
 fun EmphasizedText(text: String, modifier: Modifier = Modifier()) {
     Text(
         text = text,
-        modifier = ModifierImpl(modifier.styles + ("font-style" to "italic")),
+        modifier = modifier.style("font-style", "italic"),
         fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
     )
 }
@@ -215,12 +215,13 @@ fun StrongText(text: String, modifier: Modifier = Modifier()) {
 fun QuoteText(text: String, modifier: Modifier = Modifier()) {
     Text(
         text = text,
-        modifier = ModifierImpl(
-            modifier.styles +
-                    ("border-left" to "4px solid #e0e0e0") +
-                    ("padding-left" to "1em") +
-                    ("font-style" to "italic") +
-                    ("margin" to "1em 0")
+        modifier = modifier.withStyles(
+            mapOfCompat(
+                "border-left" to "4px solid #e0e0e0",
+                "padding-left" to "1em",
+                "font-style" to "italic",
+                "margin" to "1em 0",
+            )
         ),
         fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
         lineHeight = "1.5"
@@ -252,13 +253,14 @@ fun TruncatedText(text: String, maxLines: Int, modifier: Modifier = Modifier()) 
 fun KeyboardText(text: String, modifier: Modifier = Modifier()) {
     Text(
         text = text,
-        modifier = ModifierImpl(
-            modifier.styles +
-                    ("background-color" to "#f5f5f5") +
-                    ("padding" to "0.2em 0.4em") +
-                    ("border" to "1px solid #d0d0d0") +
-                    ("border-radius" to "3px") +
-                    ("font-size" to "0.9em")
+        modifier = modifier.withStyles(
+            mapOfCompat(
+                "background-color" to "#f5f5f5",
+                "padding" to "0.2em 0.4em",
+                "border" to "1px solid #d0d0d0",
+                "border-radius" to "3px",
+                "font-size" to "0.9em",
+            )
         ),
         fontFamily = "SFMono-Regular, Consolas, monospace",
         lineHeight = "1.4"
@@ -281,14 +283,15 @@ fun BadgeText(
 ) {
     Text(
         text = text,
-        modifier = ModifierImpl(
-            modifier.styles +
-                    ("background-color" to color) +
-                    ("color" to textColor) +
-                    ("padding" to "0.25em 0.6em") +
-                    ("border-radius" to "1em") +
-                    ("font-size" to "0.85em") +
-                    ("display" to "inline-block")
+        modifier = modifier.withStyles(
+            mapOfCompat(
+                "background-color" to color,
+                "color" to textColor,
+                "padding" to "0.25em 0.6em",
+                "border-radius" to "1em",
+                "font-size" to "0.85em",
+                "display" to "inline-block",
+            )
         ),
         fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
         lineHeight = "1.4"

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/forms/FormDefaults.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/forms/FormDefaults.kt
@@ -32,14 +32,23 @@ enum class FormTextFieldType(val htmlType: String) {
     Email("email"),
     Url("url"),
     Number("number"),
+    Date("date"),
     Password("password"),
-    Tel("tel")
+    Tel("tel"),
+    Search("search")
 }
 
 /**
  * Represents a selectable option for [FormSelect].
  */
 data class FormSelectOption(
+    val value: String,
+    val label: String,
+    val disabled: Boolean = false
+)
+
+/** Represents one native option in a server-submitted radio group. */
+data class FormRadioOption(
     val value: String,
     val label: String,
     val disabled: Boolean = false

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/forms/FormFields.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/forms/FormFields.kt
@@ -24,6 +24,8 @@ fun FormTextField(
     required: Boolean = false,
     type: FormTextFieldType = FormTextFieldType.Text,
     autoComplete: String? = null,
+    maxLength: Int? = null,
+    step: Number? = null,
     modifier: Modifier = Modifier(),
     fieldModifier: Modifier = Modifier(),
     id: String? = null
@@ -47,6 +49,17 @@ fun FormTextField(
         placeholder?.let { inputModifier = inputModifier.attribute("placeholder", it) }
         if (required) inputModifier = inputModifier.attribute("required", "true")
         autoComplete?.let { inputModifier = inputModifier.attribute("autocomplete", it) }
+        maxLength?.let {
+            require(it > 0) { "FormTextField maxLength must be greater than zero" }
+            inputModifier = inputModifier.attribute("maxlength", it.toString())
+        }
+        step?.let {
+            val numericStep = it.toDouble()
+            require(numericStep.isFinite() && numericStep > 0.0) {
+                "FormTextField step must be a finite number greater than zero"
+            }
+            inputModifier = inputModifier.attribute("step", it.toString())
+        }
         metadata.describedById?.let { inputModifier = inputModifier.ariaAttribute("describedby", it) }
         metadata.errorMessageId?.let { inputModifier = inputModifier.ariaAttribute("errormessage", it) }
 
@@ -57,6 +70,39 @@ fun FormTextField(
         )
     }
 }
+
+/** Retains the pre-limit JVM signature for already compiled 0.7.x consumers. */
+@Deprecated("Binary compatibility bridge", level = DeprecationLevel.HIDDEN)
+@Composable
+fun FormTextField(
+    name: String,
+    label: String,
+    defaultValue: String = "",
+    placeholder: String? = null,
+    description: String? = null,
+    validationMessage: String? = null,
+    required: Boolean = false,
+    type: FormTextFieldType = FormTextFieldType.Text,
+    autoComplete: String? = null,
+    modifier: Modifier = Modifier(),
+    fieldModifier: Modifier = Modifier(),
+    id: String? = null
+) = FormTextField(
+    name = name,
+    label = label,
+    defaultValue = defaultValue,
+    placeholder = placeholder,
+    description = description,
+    validationMessage = validationMessage,
+    required = required,
+    type = type,
+    autoComplete = autoComplete,
+    maxLength = null,
+    step = null,
+    modifier = modifier,
+    fieldModifier = fieldModifier,
+    id = id
+)
 
 /**
  * Multi-line text input rendered via `<textarea>`.
@@ -250,6 +296,62 @@ fun FormCheckbox(
 }
 
 /**
+ * A native, server-submitted radio group. Each option shares [name], so the browser submits the
+ * selected option without requiring hydration or a client callback.
+ */
+@Composable
+fun FormRadioGroup(
+    name: String,
+    label: String,
+    options: List<FormRadioOption>,
+    selectedValue: String? = null,
+    required: Boolean = false,
+    modifier: Modifier = Modifier(),
+    optionModifier: Modifier = Modifier(),
+    id: String? = null
+) {
+    require(options.isNotEmpty()) { "FormRadioGroup options must not be empty" }
+    require(options.map { it.value }.distinct().size == options.size) {
+        "FormRadioGroup option values must be unique"
+    }
+
+    val renderer = LocalPlatformRenderer.current
+    val groupId = rememberFieldId(name, id, "radio")
+
+    Column(modifier = FormDefaults.fieldContainerModifier().then(modifier)) {
+        Text(text = label, modifier = FormDefaults.labelModifier().id("$groupId-label"))
+        options.forEachIndexed { index, option ->
+            val optionId = "$groupId-$index"
+            Row(
+                modifier = optionModifier
+                    .style("align-items", "center")
+                    .style("gap", Spacing.xs)
+            ) {
+                var inputModifier = FormDefaults.checkboxInputModifier()
+                    .id(optionId)
+                    .attribute("name", name)
+                    .attribute("value", option.value)
+                    .ariaAttribute("labelledby", "$groupId-label")
+                if (required) inputModifier = inputModifier.attribute("required", "true")
+                if (option.disabled) inputModifier = inputModifier.attribute("disabled", "true")
+
+                renderer.renderNativeInput(
+                    type = "radio",
+                    modifier = inputModifier,
+                    value = option.value,
+                    isChecked = option.value == selectedValue
+                )
+                Label(
+                    text = option.label,
+                    modifier = FormDefaults.checkboxLabelModifier(),
+                    forElement = optionId
+                )
+            }
+        }
+    }
+}
+
+/**
  * Semantic button that triggers native form submission or reset behaviour.
  */
 @Composable
@@ -259,7 +361,10 @@ fun FormButton(
     variant: FormButtonVariant = FormButtonVariant.Primary,
     modifier: Modifier = Modifier(),
     fullWidth: Boolean = true,
-    ariaLabel: String? = null
+    ariaLabel: String? = null,
+    name: String? = null,
+    value: String? = null,
+    formId: String? = null
 ) {
     val renderer = LocalPlatformRenderer.current
     var buttonModifier = FormDefaults.buttonModifier(variant)
@@ -271,6 +376,9 @@ fun FormButton(
     if (!ariaLabel.isNullOrBlank()) {
         buttonModifier = buttonModifier.ariaAttribute("label", ariaLabel)
     }
+    name?.let { buttonModifier = buttonModifier.attribute("name", it) }
+    value?.let { buttonModifier = buttonModifier.attribute("value", it) }
+    formId?.let { buttonModifier = buttonModifier.attribute("form", it) }
 
     renderer.renderNativeButton(
         type = type.value,
@@ -279,3 +387,25 @@ fun FormButton(
         Text(text = text)
     }
 }
+
+/** Retains the pre-submit-metadata JVM signature for already compiled 0.7.x consumers. */
+@Deprecated("Binary compatibility bridge", level = DeprecationLevel.HIDDEN)
+@Composable
+fun FormButton(
+    text: String,
+    type: FormButtonType = FormButtonType.Submit,
+    variant: FormButtonVariant = FormButtonVariant.Primary,
+    modifier: Modifier = Modifier(),
+    fullWidth: Boolean = true,
+    ariaLabel: String? = null
+) = FormButton(
+    text = text,
+    type = type,
+    variant = variant,
+    modifier = modifier,
+    fullWidth = fullWidth,
+    ariaLabel = ariaLabel,
+    name = null,
+    value = null,
+    formId = null
+)

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/layout/Grid.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/layout/Grid.kt
@@ -223,7 +223,7 @@ fun Grid(
     areas?.let { gridStyles["grid-template-areas"] = it }
 
     // Create a new modifier that preserves all existing styles and attributes
-    val finalModifier = ModifierImpl(modifier.styles + gridStyles, modifier.attributes)
+    val finalModifier = modifier.withStyles(gridStyles)
 
     getPlatformRenderer().renderGrid(
         modifier = finalModifier,

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/styles/TypedStyleSheet.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/components/styles/TypedStyleSheet.kt
@@ -1,0 +1,449 @@
+package codes.yousef.summon.components.styles
+
+import codes.yousef.summon.annotation.Composable
+import codes.yousef.summon.modifier.AnimationDirection
+import codes.yousef.summon.modifier.AnimationDuration
+import codes.yousef.summon.modifier.AnimationFillMode
+import codes.yousef.summon.modifier.MediaQuery
+import codes.yousef.summon.modifier.Modifier
+import codes.yousef.summon.modifier.style
+import kotlin.jvm.JvmInline
+
+/**
+ * HTML elements that can be targeted by a [TypedStyleSheet].
+ */
+enum class StyleElement(internal val cssName: String) {
+    Html("html"),
+    Body("body"),
+    Main("main"),
+    Header("header"),
+    Footer("footer"),
+    Nav("nav"),
+    Section("section"),
+    Article("article"),
+    Aside("aside"),
+    Div("div"),
+    Span("span"),
+    Paragraph("p"),
+    Heading1("h1"),
+    Heading2("h2"),
+    Heading3("h3"),
+    Heading4("h4"),
+    Heading5("h5"),
+    Heading6("h6"),
+    Anchor("a"),
+    Button("button"),
+    Form("form"),
+    Label("label"),
+    Input("input"),
+    TextArea("textarea"),
+    Select("select"),
+    Option("option"),
+    Details("details"),
+    Summary("summary"),
+    List("ul"),
+    OrderedList("ol"),
+    ListItem("li"),
+    Image("img"),
+    Video("video"),
+    Audio("audio"),
+    Canvas("canvas"),
+    Iframe("iframe"),
+    Preformatted("pre"),
+    Code("code"),
+    Table("table"),
+    TableHead("thead"),
+    TableBody("tbody"),
+    TableRow("tr"),
+    TableHeader("th"),
+    TableCell("td")
+}
+
+/**
+ * Attribute names supported by typed selectors.
+ *
+ * Use [data] and [aria] for application-specific data and accessibility attributes.
+ */
+class StyleAttribute private constructor(internal val cssName: String) {
+    companion object {
+        val Open = StyleAttribute("open")
+        val Disabled = StyleAttribute("disabled")
+        val Checked = StyleAttribute("checked")
+        val Selected = StyleAttribute("selected")
+        val Hidden = StyleAttribute("hidden")
+        val Type = StyleAttribute("type")
+        val Style = StyleAttribute("style")
+        val Role = StyleAttribute("role")
+        val Direction = StyleAttribute("dir")
+        val Language = StyleAttribute("lang")
+        val AriaCurrent = aria("current")
+        val AriaExpanded = aria("expanded")
+
+        fun data(name: String): StyleAttribute = StyleAttribute("data-${validatedName(name)}")
+
+        fun aria(name: String): StyleAttribute = StyleAttribute("aria-${validatedName(name)}")
+
+        private fun validatedName(name: String): String {
+            require(name.matches(Regex("[a-zA-Z_][a-zA-Z0-9_-]*"))) {
+                "Attribute names must contain only letters, digits, underscores, and hyphens"
+            }
+            return name
+        }
+    }
+}
+
+enum class AttributeMatch(internal val operator: String) {
+    Equals("="),
+    IncludesWord("~="),
+    StartsWith("^="),
+    EndsWith("$="),
+    Contains("*=")
+}
+
+sealed class StylePseudoClass(internal val css: String) {
+    data object Hover : StylePseudoClass("hover")
+    data object Focus : StylePseudoClass("focus")
+    data object FocusVisible : StylePseudoClass("focus-visible")
+    data object FocusWithin : StylePseudoClass("focus-within")
+    data object Active : StylePseudoClass("active")
+    data object Visited : StylePseudoClass("visited")
+    data object Disabled : StylePseudoClass("disabled")
+    data object Checked : StylePseudoClass("checked")
+    data object FirstChild : StylePseudoClass("first-child")
+    data object LastChild : StylePseudoClass("last-child")
+    data object OnlyChild : StylePseudoClass("only-child")
+    data object Empty : StylePseudoClass("empty")
+
+    class NthChild private constructor(private val expression: String) :
+        StylePseudoClass("nth-child($expression)") {
+        companion object {
+            val Odd = NthChild("odd")
+            val Even = NthChild("even")
+
+            fun index(index: Int): NthChild {
+                require(index > 0) { "nth-child index must be greater than zero" }
+                return NthChild(index.toString())
+            }
+
+            fun sequence(step: Int, offset: Int = 0): NthChild {
+                require(step != 0) { "nth-child sequence step must not be zero" }
+                val suffix = when {
+                    offset > 0 -> "+$offset"
+                    offset < 0 -> offset.toString()
+                    else -> ""
+                }
+                return NthChild("${step}n$suffix")
+            }
+        }
+    }
+}
+
+enum class StylePseudoElement(internal val css: String) {
+    Before("before"),
+    After("after"),
+    Placeholder("placeholder"),
+    Selection("selection"),
+    Marker("marker"),
+    FileSelectorButton("file-selector-button"),
+    WebkitDetailsMarker("-webkit-details-marker"),
+    WebkitScrollbar("-webkit-scrollbar"),
+    WebkitScrollbarTrack("-webkit-scrollbar-track"),
+    WebkitScrollbarThumb("-webkit-scrollbar-thumb"),
+    WebkitSearchCancelButton("-webkit-search-cancel-button"),
+    WebkitSliderThumb("-webkit-slider-thumb")
+}
+
+/**
+ * A structured selector for [TypedStyleSheet]. It cannot contain arbitrary selector syntax.
+ */
+sealed class StyleSelector {
+    internal abstract fun render(): String
+
+    data object Universal : StyleSelector() {
+        override fun render() = "*"
+    }
+
+    data object Root : StyleSelector() {
+        override fun render() = ":root"
+    }
+
+    private data class ElementSelector(val element: StyleElement) : StyleSelector() {
+        override fun render() = element.cssName
+    }
+
+    private data class ClassSelector(val name: String) : StyleSelector() {
+        override fun render() = ".$name"
+    }
+
+    private data class IdSelector(val name: String) : StyleSelector() {
+        override fun render() = "#$name"
+    }
+
+    private data class WithClass(val base: StyleSelector, val name: String) : StyleSelector() {
+        override fun render() = "${base.render()}.$name"
+    }
+
+    private data class WithAttribute(
+        val base: StyleSelector,
+        val attribute: StyleAttribute,
+        val value: String?,
+        val match: AttributeMatch,
+        val caseInsensitive: Boolean
+    ) : StyleSelector() {
+        override fun render(): String {
+            val attributeSelector = if (value == null) {
+                "[${attribute.cssName}]"
+            } else {
+                val flag = if (caseInsensitive) " i" else ""
+                "[${attribute.cssName}${match.operator}\"${escapeCssString(value)}\"$flag]"
+            }
+            return base.render() + attributeSelector
+        }
+    }
+
+    private data class WithPseudoClass(
+        val base: StyleSelector,
+        val pseudoClass: StylePseudoClass
+    ) : StyleSelector() {
+        override fun render() = "${base.render()}:${pseudoClass.css}"
+    }
+
+    private data class WithPseudoElement(
+        val base: StyleSelector,
+        val pseudoElement: StylePseudoElement
+    ) : StyleSelector() {
+        override fun render() = "${base.render()}::${pseudoElement.css}"
+    }
+
+    private data class Negated(val base: StyleSelector, val excluded: StyleSelector) : StyleSelector() {
+        override fun render() = "${base.render()}:not(${excluded.render()})"
+    }
+
+    private data class Related(
+        val parent: StyleSelector,
+        val combinator: String,
+        val target: StyleSelector
+    ) : StyleSelector() {
+        override fun render() = "${parent.render()}$combinator${target.render()}"
+    }
+
+    private data class Group(val selectors: List<StyleSelector>) : StyleSelector() {
+        override fun render() = selectors.joinToString(", ") { it.render() }
+    }
+
+    fun withClass(name: String): StyleSelector = WithClass(this, validateIdentifier(name))
+
+    fun attribute(
+        attribute: StyleAttribute,
+        value: String? = null,
+        match: AttributeMatch = AttributeMatch.Equals,
+        caseInsensitive: Boolean = false
+    ): StyleSelector = WithAttribute(this, attribute, value, match, caseInsensitive)
+
+    fun pseudoClass(pseudoClass: StylePseudoClass): StyleSelector =
+        WithPseudoClass(this, pseudoClass)
+
+    fun pseudoElement(pseudoElement: StylePseudoElement): StyleSelector =
+        WithPseudoElement(this, pseudoElement)
+
+    fun not(excluded: StyleSelector): StyleSelector = Negated(this, excluded)
+
+    fun descendant(target: StyleSelector): StyleSelector = Related(this, " ", target)
+
+    fun child(target: StyleSelector): StyleSelector = Related(this, " > ", target)
+
+    fun adjacentSibling(target: StyleSelector): StyleSelector = Related(this, " + ", target)
+
+    fun generalSibling(target: StyleSelector): StyleSelector = Related(this, " ~ ", target)
+
+    fun or(other: StyleSelector, vararg additional: StyleSelector): StyleSelector =
+        Group(listOf(this, other) + additional)
+
+    companion object {
+        fun element(element: StyleElement): StyleSelector = ElementSelector(element)
+
+        fun className(name: String): StyleSelector = ClassSelector(validateIdentifier(name))
+
+        fun id(name: String): StyleSelector = IdSelector(validateIdentifier(name))
+
+        fun all(first: StyleSelector, second: StyleSelector, vararg additional: StyleSelector): StyleSelector =
+            Group(listOf(first, second) + additional)
+
+        fun all(selectors: Iterable<StyleSelector>): StyleSelector {
+            val values = selectors.toList()
+            require(values.size >= 2) { "A selector group requires at least two selectors" }
+            return Group(values)
+        }
+
+        private fun validateIdentifier(value: String): String {
+            require(value.matches(Regex("-?[_a-zA-Z][_a-zA-Z0-9-]*"))) {
+                "Style identifiers must be valid CSS identifiers without selector syntax"
+            }
+            return value
+        }
+
+        private fun escapeCssString(value: String): String = buildString(value.length) {
+            value.forEach { character ->
+                when (character) {
+                    '\\' -> append("\\\\")
+                    '"' -> append("\\\"")
+                    '\n' -> append("\\a ")
+                    '\r' -> append("\\d ")
+                    '\u000c' -> append("\\c ")
+                    else -> append(character)
+                }
+            }
+        }
+    }
+}
+
+@JvmInline
+value class AnimationName private constructor(internal val cssName: String) {
+    companion object {
+        fun named(name: String): AnimationName {
+            require(name.matches(Regex("-?[_a-zA-Z][_a-zA-Z0-9-]*"))) {
+                "Animation names must be valid identifiers"
+            }
+            return AnimationName(name)
+        }
+    }
+}
+
+private sealed interface TypedStyleEntry {
+    fun render(): String
+}
+
+private data class TypedRule(
+    val selector: StyleSelector,
+    val declarations: Modifier,
+    val priority: StyleRulePriority
+) : TypedStyleEntry {
+    override fun render(): String = "${selector.render()} { ${declarations.renderDeclarations(priority)} }"
+}
+
+private data class TypedMediaBlock(
+    val query: MediaQuery,
+    val entries: List<TypedStyleEntry>
+) : TypedStyleEntry {
+    override fun render(): String =
+        "@media $query { ${entries.joinToString(" ") { it.render() }} }"
+}
+
+private data class TypedKeyframes(
+    val name: AnimationName,
+    val frames: List<Keyframe>
+) : TypedStyleEntry {
+    override fun render(): String =
+        "@keyframes ${name.cssName} { ${frames.joinToString(" ") { it.render() }} }"
+}
+
+internal data class Keyframe(val position: String, val declarations: Modifier) {
+    fun render(): String = "$position { ${declarations.renderDeclarations()} }"
+}
+
+class TypedKeyframesScope internal constructor() {
+    private val frames = mutableListOf<Keyframe>()
+
+    fun from(modifier: Modifier) {
+        frame(0, modifier)
+    }
+
+    fun to(modifier: Modifier) {
+        frame(100, modifier)
+    }
+
+    fun frame(percent: Int, modifier: Modifier) {
+        require(percent in 0..100) { "Keyframe position must be between 0 and 100" }
+        if (modifier.styles.isNotEmpty()) frames += Keyframe("$percent%", modifier)
+    }
+
+    internal fun build(): List<Keyframe> = frames.toList()
+}
+
+class TypedStyleSheetScope internal constructor() {
+    private val entries = mutableListOf<TypedStyleEntry>()
+
+    fun rule(
+        selector: StyleSelector,
+        modifier: Modifier,
+        priority: StyleRulePriority = StyleRulePriority.Normal
+    ) {
+        if (modifier.styles.isNotEmpty()) entries += TypedRule(selector, modifier, priority)
+    }
+
+    fun media(query: MediaQuery, block: TypedStyleSheetScope.() -> Unit) {
+        require(query !is MediaQuery.Custom) {
+            "TypedStyleSheet does not accept raw custom media-query strings"
+        }
+        val nested = TypedStyleSheetScope().apply(block).entries
+        if (nested.isNotEmpty()) entries += TypedMediaBlock(query, nested.toList())
+    }
+
+    fun keyframes(name: AnimationName, block: TypedKeyframesScope.() -> Unit) {
+        val frames = TypedKeyframesScope().apply(block).build()
+        if (frames.isNotEmpty()) entries += TypedKeyframes(name, frames)
+    }
+
+    internal fun render(): String = entries.joinToString("\n") { it.render() }
+}
+
+/** Controls whether a typed global rule is allowed to override inline component defaults. */
+enum class StyleRulePriority {
+    Normal,
+    Important
+}
+
+/**
+ * Emits global rules from structured selectors and typed [Modifier] declarations.
+ * Application code never needs to author CSS syntax.
+ */
+@Composable
+fun TypedStyleSheet(block: TypedStyleSheetScope.() -> Unit) {
+    val css = TypedStyleSheetScope().apply(block).render()
+    if (css.isNotEmpty()) GlobalStyle(css)
+}
+
+fun Modifier.animation(
+    name: AnimationName,
+    duration: AnimationDuration = AnimationDuration.Medium,
+    easing: AnimationEasing = AnimationEasing.Ease,
+    delay: AnimationDuration = AnimationDuration.Instant,
+    iterationCount: AnimationIterationCount = AnimationIterationCount.Once,
+    direction: AnimationDirection = AnimationDirection.Normal,
+    fillMode: AnimationFillMode = AnimationFillMode.None
+): Modifier = style(
+    "animation",
+    "${name.cssName} $duration ${easing.css} $delay ${iterationCount.css} $direction $fillMode"
+)
+
+enum class AnimationEasing(internal val css: String) {
+    Linear("linear"),
+    Ease("ease"),
+    EaseIn("ease-in"),
+    EaseOut("ease-out"),
+    EaseInOut("ease-in-out"),
+    StepStart("step-start"),
+    StepEnd("step-end")
+}
+
+sealed class AnimationIterationCount(internal val css: String) {
+    data object Once : AnimationIterationCount("1")
+    data object Infinite : AnimationIterationCount("infinite")
+
+    class Times(count: Int) : AnimationIterationCount(count.also {
+        require(it > 0) { "Animation iteration count must be greater than zero" }
+    }.toString())
+}
+
+private fun Modifier.renderDeclarations(
+    priority: StyleRulePriority = StyleRulePriority.Normal
+): String = styles.entries.joinToString("; ", postfix = ";") { (property, value) ->
+    val importance = if (priority == StyleRulePriority.Important) " !important" else ""
+    "${property.toKebabCase()}: ${value.normalizedCssNumber()}$importance"
+}
+
+private fun String.normalizedCssNumber(): String =
+    if (matches(Regex("-?[0-9]+\\.0"))) dropLast(2) else this
+
+private fun String.toKebabCase(): String =
+    if ('-' in this) this else replace(Regex("([a-z])([A-Z])"), "$1-$2").lowercase()

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/AccessibilityModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/AccessibilityModifiers.kt
@@ -148,7 +148,14 @@ package codes.yousef.summon.modifier
  */
 fun Modifier.removeAttribute(name: String): Modifier {
     if (!attributes.containsKey(name)) return this
-    return ModifierImpl(styles, attributes.filterKeys { it != name }, eventHandlers, complexEventHandlers, pseudoElements)
+    return ModifierImpl(
+        styles,
+        attributes.filterKeys { it != name },
+        eventHandlers,
+        complexEventHandlers,
+        pseudoElements,
+        conditionalStyles
+    )
 }
 
 // role(String) removed - exists as member function in Modifier class

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/BackgroundModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/BackgroundModifiers.kt
@@ -2,6 +2,12 @@ package codes.yousef.summon.modifier
 
 import kotlin.jvm.JvmName
 
+/** Controls whether a background scrolls with the page or stays anchored to the viewport. */
+enum class BackgroundAttachment(val value: String) {
+    Scroll("scroll"),
+    Fixed("fixed"),
+    Local("local")
+}
 
 /**
  * Background-related [Modifier] helpers extracted from the legacy `StylingModifiers` monolith.
@@ -37,6 +43,10 @@ fun Modifier.backgroundPosition(value: String): Modifier =
  */
 fun Modifier.backgroundRepeat(value: String): Modifier =
     style("background-repeat", value)
+
+/** Applies a typed CSS `background-attachment` declaration. */
+fun Modifier.backgroundAttachment(value: BackgroundAttachment): Modifier =
+    style("background-attachment", value.value)
 
 /**
  * Applies a CSS `background-clip` declaration using a raw string value.

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/BorderModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/BorderModifiers.kt
@@ -49,3 +49,11 @@ fun Modifier.border(
     radius?.let { result = result.borderRadius(it) }
     return result
 }
+
+/** Applies a complete border declaration to one physical side without affecting the others. */
+fun Modifier.border(
+    side: BorderSide,
+    width: Number,
+    style: BorderStyle,
+    color: String
+): Modifier = style("border-${side.value}", "${width.px} ${style.value} $color")

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/ConditionalStyleDefinitions.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/ConditionalStyleDefinitions.kt
@@ -1,0 +1,60 @@
+package codes.yousef.summon.modifier
+
+/**
+ * A structured CSS rule that cannot be represented by an element's inline style attribute.
+ *
+ * Platform renderers consume these definitions directly. The legacy serialized data attributes
+ * remain available for compatibility, but are not the source of truth for new renderers.
+ */
+sealed interface ConditionalStyleDefinition {
+    val styles: Map<String, String>
+}
+
+/** Pseudo-class states supported by Summon's conditional modifier APIs. */
+enum class ConditionalStyleState {
+    HOVER,
+    FOCUS,
+    FOCUS_VISIBLE,
+    ACTIVE,
+    FOCUS_WITHIN,
+    FIRST_CHILD,
+    LAST_CHILD,
+    NTH_CHILD,
+    ONLY_CHILD,
+    VISITED,
+    DISABLED,
+    CHECKED
+}
+
+/**
+ * Styles applied while an element matches [state].
+ *
+ * [argument] is required for [ConditionalStyleState.NTH_CHILD] and omitted for all other states.
+ */
+data class StateStyleDefinition(
+    val state: ConditionalStyleState,
+    override val styles: Map<String, String>,
+    val argument: String? = null
+) : ConditionalStyleDefinition {
+    init {
+        require(state == ConditionalStyleState.NTH_CHILD || argument == null) {
+            "Only NTH_CHILD accepts a state argument"
+        }
+        require(state != ConditionalStyleState.NTH_CHILD || !argument.isNullOrBlank()) {
+            "NTH_CHILD requires a non-blank argument"
+        }
+    }
+}
+
+/** Styles applied while [query] matches. */
+data class MediaStyleDefinition(
+    val query: MediaQuery,
+    override val styles: Map<String, String>
+) : ConditionalStyleDefinition
+
+/** Appends a structured conditional style while preserving all existing modifier state. */
+internal fun Modifier.withConditionalStyle(definition: ConditionalStyleDefinition): Modifier =
+    when (this) {
+        is ModifierImpl -> copy(conditionalStyles = conditionalStyles + definition)
+        else -> ModifierImpl(conditionalStyles = listOf(definition))
+    }

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/CoreModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/CoreModifiers.kt
@@ -28,7 +28,14 @@ inline fun Modifier.applyIf(condition: Boolean, block: Modifier.() -> Modifier):
  * Creates a clone of this modifier
  */
 fun Modifier.clone(): Modifier {
-    return ModifierImpl(styles.toMap(), attributes.toMap(), eventHandlers.toMap(), complexEventHandlers.toMap(), pseudoElements.toList())
+    return ModifierImpl(
+        styles.toMap(),
+        attributes.toMap(),
+        eventHandlers.toMap(),
+        complexEventHandlers.toMap(),
+        pseudoElements.toList(),
+        conditionalStyles.toList()
+    )
 }
 
 /**

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/MediaQueryModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/MediaQueryModifiers.kt
@@ -252,7 +252,9 @@ fun Modifier.mediaQuery(query: MediaQuery, builder: Modifier.() -> Modifier): Mo
         "$existingQueries|$queryString{$stylesString}"
     }
 
-    return attribute("data-media-queries", newQueries)
+    return withConditionalStyle(
+        MediaStyleDefinition(query, mediaModifier.styles)
+    ).attribute("data-media-queries", newQueries)
 }
 
 /**

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/Modifier.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/Modifier.kt
@@ -192,6 +192,7 @@ import kotlin.js.JsName
  *
  * @property styles Map of CSS property names to values
  * @property attributes Map of HTML attribute names to values (renamed to `htmlAttributes` in JS)
+ * @property conditionalStyles Structured state, media, and scoped rules for platform renderers
  * @constructor Creates a new Modifier with the specified styles and attributes
  * @see codes.yousef.summon.runtime.PlatformRenderer
  * @see codes.yousef.summon.components
@@ -203,6 +204,7 @@ interface Modifier {
     val eventHandlers: Map<String, () -> Unit> get() = emptyMap()
     val complexEventHandlers: Map<String, (Any) -> Unit> get() = emptyMap()
     val pseudoElements: List<PseudoElementDefinition> get() = emptyList()
+    val conditionalStyles: List<ConditionalStyleDefinition> get() = emptyList()
 
     /**
      * Combines this modifier with another modifier.
@@ -227,7 +229,8 @@ data class ModifierImpl(
     override val attributes: Map<String, String> = emptyMap(),
     override val eventHandlers: Map<String, () -> Unit> = emptyMap(),
     override val complexEventHandlers: Map<String, (Any) -> Unit> = emptyMap(),
-    override val pseudoElements: List<PseudoElementDefinition> = emptyList()
+    override val pseudoElements: List<PseudoElementDefinition> = emptyList(),
+    override val conditionalStyles: List<ConditionalStyleDefinition> = emptyList()
 ) : Modifier {
     override infix fun then(other: Modifier): Modifier {
         return if (other === Modifier) this
@@ -238,7 +241,8 @@ data class ModifierImpl(
                 attributes = this.attributes + other.attributes,
                 eventHandlers = this.eventHandlers + other.eventHandlers,
                 complexEventHandlers = this.complexEventHandlers + other.complexEventHandlers,
-                pseudoElements = this.pseudoElements + other.pseudoElements
+                pseudoElements = this.pseudoElements + other.pseudoElements,
+                conditionalStyles = this.conditionalStyles + other.conditionalStyles
             )
         }
     }
@@ -251,6 +255,7 @@ data class ModifierImpl(
  * @param attributes Initial map of HTML attributes
  * @param eventHandlers Initial map of event handlers
  * @param pseudoElements Initial list of pseudo-element definitions
+ * @param conditionalStyles Initial list of structured conditional style definitions
  * @return A new ModifierImpl instance
  */
 @Suppress("FunctionName")
@@ -258,8 +263,9 @@ fun Modifier(
     styles: Map<String, String> = emptyMap(),
     attributes: Map<String, String> = emptyMap(),
     eventHandlers: Map<String, () -> Unit> = emptyMap(),
-    pseudoElements: List<PseudoElementDefinition> = emptyList()
-): Modifier = ModifierImpl(styles, attributes, eventHandlers, emptyMap(), pseudoElements)
+    pseudoElements: List<PseudoElementDefinition> = emptyList(),
+    conditionalStyles: List<ConditionalStyleDefinition> = emptyList()
+): Modifier = ModifierImpl(styles, attributes, eventHandlers, emptyMap(), pseudoElements, conditionalStyles)
 
 /**
  * Generic style method for adding any CSS property.
@@ -594,13 +600,18 @@ fun Modifier.attributes(attrs: Map<String, String>): Modifier =
 fun Modifier.hover(hoverStyles: Map<String, String>): Modifier {
     val currentAttributes = (this as? ModifierImpl)?.attributes ?: emptyMap()
     val currentHover = currentAttributes["data-hover-styles"]?.let { prev ->
-        prev.splitCompat(';').associate {
-            val parts = it.splitCompat(':')
-            parts[0].trim() to parts[1].trim()
-        } + hoverStyles
+        prev.splitCompat(';')
+            .filter { it.isNotBlank() }
+            .mapNotNull { rule ->
+                val parts = rule.splitCompat(':', limit = 2)
+                if (parts.size == 2) parts[0].trim() to parts[1].trim() else null
+            }
+            .toMap() + hoverStyles
     } ?: hoverStyles
     val hoverString = currentHover.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-hover-styles", hoverString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.HOVER, hoverStyles)
+    ).attribute("data-hover-styles", hoverString)
 }
 
 /**

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/PseudoElementModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/PseudoElementModifiers.kt
@@ -49,7 +49,8 @@ private fun Modifier.withPseudoElement(
         host.attributes,
         host.eventHandlers,
         host.complexEventHandlers,
-        host.pseudoElements + definition
+        host.pseudoElements + definition,
+        host.conditionalStyles
     )
 }
 

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/ScopedStyleModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/ScopedStyleModifiers.kt
@@ -129,8 +129,8 @@ enum class SelectorType(val combinator: String) {
 data class ScopedStyleDefinition(
     val selector: String,
     val selectorType: SelectorType,
-    val styles: Map<String, String>
-)
+    override val styles: Map<String, String>
+) : ConditionalStyleDefinition
 
 // ============================================
 // Scoped Style Modifier Functions
@@ -243,7 +243,9 @@ private fun Modifier.scopedStyle(
         "$existingScoped||$encoded"  // Use || as separator between definitions
     }
 
-    return attribute("data-scoped-styles", newScoped)
+    return withConditionalStyle(
+        ScopedStyleDefinition(selector, selectorType, scopedModifier.styles)
+    ).attribute("data-scoped-styles", newScoped)
 }
 
 // ============================================

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/TransitionModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/TransitionModifiers.kt
@@ -118,7 +118,22 @@ fun Modifier.focus(focusModifier: Modifier): Modifier =
 fun Modifier.focus(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val focusString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-focus-styles", focusString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.FOCUS, styles)
+    ).attribute("data-focus-styles", focusString)
+}
+
+/** Applies styles when keyboard-style focus should be visibly indicated. */
+fun Modifier.focusVisible(focusVisibleModifier: Modifier): Modifier =
+    focusVisible(focusVisibleModifier.styles)
+
+/** Applies styles while the element matches the `:focus-visible` state. */
+fun Modifier.focusVisible(styles: Map<String, String>): Modifier {
+    if (styles.isEmpty()) return this
+    val serialized = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.FOCUS_VISIBLE, styles)
+    ).attribute("data-focus-visible-styles", serialized)
 }
 
 /**
@@ -139,7 +154,9 @@ fun Modifier.active(activeModifier: Modifier): Modifier =
 fun Modifier.active(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val activeString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-active-styles", activeString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.ACTIVE, styles)
+    ).attribute("data-active-styles", activeString)
 }
 
 /**
@@ -160,7 +177,9 @@ fun Modifier.focusWithin(focusWithinModifier: Modifier): Modifier =
 fun Modifier.focusWithin(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val focusWithinString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-focus-within-styles", focusWithinString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.FOCUS_WITHIN, styles)
+    ).attribute("data-focus-within-styles", focusWithinString)
 }
 
 /**
@@ -181,7 +200,9 @@ fun Modifier.firstChild(firstChildModifier: Modifier): Modifier =
 fun Modifier.firstChild(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val firstChildString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-first-child-styles", firstChildString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.FIRST_CHILD, styles)
+    ).attribute("data-first-child-styles", firstChildString)
 }
 
 /**
@@ -202,7 +223,9 @@ fun Modifier.lastChild(lastChildModifier: Modifier): Modifier =
 fun Modifier.lastChild(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val lastChildString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-last-child-styles", lastChildString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.LAST_CHILD, styles)
+    ).attribute("data-last-child-styles", lastChildString)
 }
 
 /**
@@ -225,7 +248,9 @@ fun Modifier.nthChild(n: String, nthChildModifier: Modifier): Modifier =
 fun Modifier.nthChild(n: String, styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val nthChildString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-nth-child-styles", "$n:$nthChildString")
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.NTH_CHILD, styles, n)
+    ).attribute("data-nth-child-styles", "$n:$nthChildString")
 }
 
 /**
@@ -246,7 +271,9 @@ fun Modifier.onlyChild(onlyChildModifier: Modifier): Modifier =
 fun Modifier.onlyChild(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val onlyChildString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-only-child-styles", onlyChildString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.ONLY_CHILD, styles)
+    ).attribute("data-only-child-styles", onlyChildString)
 }
 
 /**
@@ -267,7 +294,9 @@ fun Modifier.visited(visitedModifier: Modifier): Modifier =
 fun Modifier.visited(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val visitedString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-visited-styles", visitedString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.VISITED, styles)
+    ).attribute("data-visited-styles", visitedString)
 }
 
 /**
@@ -288,7 +317,9 @@ fun Modifier.disabledStyles(disabledModifier: Modifier): Modifier =
 fun Modifier.disabledStyles(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val disabledString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-disabled-styles", disabledString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.DISABLED, styles)
+    ).attribute("data-disabled-styles", disabledString)
 }
 
 /**
@@ -309,5 +340,7 @@ fun Modifier.checkedStyles(checkedModifier: Modifier): Modifier =
 fun Modifier.checkedStyles(styles: Map<String, String>): Modifier {
     if (styles.isEmpty()) return this
     val checkedString = styles.entries.joinToString(";") { "${it.key}:${it.value}" }
-    return attribute("data-checked-styles", checkedString)
+    return withConditionalStyle(
+        StateStyleDefinition(ConditionalStyleState.CHECKED, styles)
+    ).attribute("data-checked-styles", checkedString)
 }

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/TypedCssModifiers.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/modifier/TypedCssModifiers.kt
@@ -1,0 +1,344 @@
+package codes.yousef.summon.modifier
+
+import codes.yousef.summon.components.ScrollableComponent
+import codes.yousef.summon.core.style.Color
+import codes.yousef.summon.extensions.px
+import codes.yousef.summon.i18n.LayoutDirection
+
+/** Controls how words may be broken when text would otherwise overflow. */
+enum class WordBreak(val value: String) {
+    Normal("normal"),
+    BreakAll("break-all"),
+    KeepAll("keep-all"),
+    BreakWord("break-word");
+
+    override fun toString(): String = value
+}
+
+/** Controls whether otherwise unbreakable text may wrap. */
+enum class OverflowWrap(val value: String) {
+    Normal("normal"),
+    BreakWord("break-word"),
+    Anywhere("anywhere");
+
+    override fun toString(): String = value
+}
+
+/** Controls how clipped inline content is represented. */
+enum class TextOverflow(val value: String) {
+    Clip("clip"),
+    Ellipsis("ellipsis");
+
+    override fun toString(): String = value
+}
+
+/** Selects the box model used to calculate an element's dimensions. */
+enum class BoxSizing(val value: String) {
+    ContentBox("content-box"),
+    BorderBox("border-box");
+
+    override fun toString(): String = value
+}
+
+/** Declares the color schemes in which an element can be comfortably rendered. */
+enum class ColorScheme(val value: String) {
+    Normal("normal"),
+    Light("light"),
+    Dark("dark"),
+    LightDark("light dark"),
+    DarkLight("dark light"),
+    OnlyLight("only light"),
+    OnlyDark("only dark");
+
+    override fun toString(): String = value
+}
+
+/** Common marker styles accepted by the CSS list-style-type property. */
+enum class ListStyleType(val value: String) {
+    None("none"),
+    Disc("disc"),
+    Circle("circle"),
+    Square("square"),
+    Decimal("decimal"),
+    DecimalLeadingZero("decimal-leading-zero"),
+    LowerAlpha("lower-alpha"),
+    UpperAlpha("upper-alpha"),
+    LowerRoman("lower-roman"),
+    UpperRoman("upper-roman"),
+    DisclosureOpen("disclosure-open"),
+    DisclosureClosed("disclosure-closed");
+
+    override fun toString(): String = value
+}
+
+/** Standard values accepted by the CSS scrollbar-width property. */
+enum class ScrollbarWidth(val value: String) {
+    Auto("auto"),
+    Thin("thin"),
+    None("none");
+
+    override fun toString(): String = value
+}
+
+/** Standard line styles accepted by CSS outlines. */
+enum class OutlineStyle(val value: String) {
+    Auto("auto"),
+    None("none"),
+    Dotted("dotted"),
+    Dashed("dashed"),
+    Solid("solid"),
+    Double("double"),
+    Groove("groove"),
+    Ridge("ridge"),
+    Inset("inset"),
+    Outset("outset");
+
+    override fun toString(): String = value
+}
+
+/** Applies the inline text/layout direction represented by the framework i18n model. */
+fun Modifier.direction(value: LayoutDirection): Modifier =
+    style("direction", value.name.lowercase())
+
+/**
+ * A structured CSS text shadow declaration.
+ *
+ * Use [pixels] when all offsets are pixel values, or construct a value directly
+ * when CSS units such as `rem`, `em`, or `calc(...)` are required.
+ */
+data class TextShadow(
+    val offsetX: String,
+    val offsetY: String,
+    val blurRadius: String = "0",
+    val color: String? = null,
+) {
+    init {
+        require(offsetX.isNotBlank()) { "TextShadow offsetX must not be blank" }
+        require(offsetY.isNotBlank()) { "TextShadow offsetY must not be blank" }
+        require(blurRadius.isNotBlank()) { "TextShadow blurRadius must not be blank" }
+        require(color == null || color.isNotBlank()) { "TextShadow color must not be blank" }
+    }
+
+    internal fun toCssValue(): String = buildList {
+        add(offsetX)
+        add(offsetY)
+        add(blurRadius)
+        color?.let(::add)
+    }.joinToString(" ")
+
+    companion object {
+        /** Creates a text shadow whose dimensions are expressed in pixels. */
+        fun pixels(
+            offsetX: Number,
+            offsetY: Number,
+            blurRadius: Number = 0,
+            color: Color? = null,
+        ): TextShadow = TextShadow(
+            offsetX = offsetX.px,
+            offsetY = offsetY.px,
+            blurRadius = blurRadius.px,
+            color = color?.toCssString(),
+        )
+    }
+}
+
+/** Applies a custom text-shadow declaration. */
+fun Modifier.textShadow(value: String): Modifier = style("text-shadow", value)
+
+/** Applies one or more structured text shadows. */
+fun Modifier.textShadow(vararg shadows: TextShadow): Modifier {
+    require(shadows.isNotEmpty()) { "textShadow requires at least one shadow" }
+    return style("text-shadow", shadows.joinToString(", ") { it.toCssValue() })
+}
+
+/** Sets the distance between text and its decoration line. */
+fun Modifier.textUnderlineOffset(value: String): Modifier = style("text-underline-offset", value)
+
+/** Sets the text-decoration offset in pixels. */
+fun Modifier.textUnderlineOffset(value: Number): Modifier = textUnderlineOffset(value.px)
+
+/** Sets word-break using a type-safe CSS value. */
+fun Modifier.wordBreak(value: WordBreak): Modifier = style("word-break", value.value)
+
+/** Sets a custom word-break value. */
+fun Modifier.wordBreak(value: String): Modifier = style("word-break", value)
+
+/** Sets overflow-wrap using a type-safe CSS value. */
+fun Modifier.overflowWrap(value: OverflowWrap): Modifier = style("overflow-wrap", value.value)
+
+/** Sets a custom overflow-wrap value. */
+fun Modifier.overflowWrap(value: String): Modifier = style("overflow-wrap", value)
+
+/** Sets text-overflow using a type-safe CSS value. */
+fun Modifier.textOverflow(value: TextOverflow): Modifier = style("text-overflow", value.value)
+
+/** Sets a custom text-overflow value. */
+fun Modifier.textOverflow(value: String): Modifier = style("text-overflow", value)
+
+/**
+ * Limits content to [lines] lines.
+ *
+ * The WebKit declaration is emitted by default for compatibility. This modifier
+ * intentionally does not change display or overflow so callers retain layout control.
+ */
+fun Modifier.lineClamp(lines: Int, includeWebkitFallback: Boolean = true): Modifier {
+    require(lines > 0) { "lineClamp lines must be greater than zero" }
+    var result = style("line-clamp", lines.toString())
+    if (includeWebkitFallback) {
+        result = result.style("-webkit-line-clamp", lines.toString())
+    }
+    return result
+}
+
+/** Sets box-sizing using a type-safe CSS value. */
+fun Modifier.boxSizing(value: BoxSizing): Modifier = style("box-sizing", value.value)
+
+/** Sets a custom box-sizing value. */
+fun Modifier.boxSizing(value: String): Modifier = style("box-sizing", value)
+
+/** Sets color-scheme using a type-safe standard value. */
+fun Modifier.colorScheme(value: ColorScheme): Modifier = style("color-scheme", value.value)
+
+/** Sets a custom color-scheme declaration. */
+fun Modifier.colorScheme(value: String): Modifier = style("color-scheme", value)
+
+/** Applies an arbitrary CSS list-style shorthand. */
+fun Modifier.listStyle(value: String): Modifier = style("list-style", value)
+
+/** Applies a marker type through the CSS list-style shorthand. */
+fun Modifier.listStyle(type: ListStyleType): Modifier = listStyle(type.value)
+
+/** Sets list-style-type using a type-safe standard marker. */
+fun Modifier.listStyleType(value: ListStyleType): Modifier = style("list-style-type", value.value)
+
+/** Sets a custom list-style-type declaration, including custom counter styles. */
+fun Modifier.listStyleType(value: String): Modifier = style("list-style-type", value)
+
+/** Applies a pixel-valued CSS inset shorthand. */
+fun Modifier.inset(value: Number): Modifier = inset(value.px)
+
+/** Applies pixel-valued vertical and horizontal insets. */
+fun Modifier.inset(vertical: Number, horizontal: Number): Modifier =
+    inset(vertical.px, horizontal.px)
+
+/** Applies four explicit pixel-valued insets. */
+fun Modifier.inset(top: Number, right: Number, bottom: Number, left: Number): Modifier =
+    inset(top.px, right.px, bottom.px, left.px)
+
+/** Sets the logical inline-start inset. */
+fun Modifier.insetInlineStart(value: String): Modifier = style("inset-inline-start", value)
+
+/** Sets the logical inline-start inset in pixels. */
+fun Modifier.insetInlineStart(value: Number): Modifier = insetInlineStart(value.px)
+
+/** Sets the logical inline-end inset. */
+fun Modifier.insetInlineEnd(value: String): Modifier = style("inset-inline-end", value)
+
+/** Sets the logical inline-end inset in pixels. */
+fun Modifier.insetInlineEnd(value: Number): Modifier = insetInlineEnd(value.px)
+
+/** Sets the scrollbar thumb and track colors. */
+fun Modifier.scrollbarColor(
+    thumb: String,
+    track: String,
+    component: ScrollableComponent? = null,
+): Modifier = style("scrollbar-color", "$thumb $track")
+
+/** Sets the scrollbar thumb and track colors using typed colors. */
+fun Modifier.scrollbarColor(
+    thumb: Color,
+    track: Color,
+    component: ScrollableComponent? = null,
+): Modifier = scrollbarColor(thumb.toCssString(), track.toCssString(), component)
+
+/** Sets scrollbar width using a type-safe CSS value. */
+fun Modifier.scrollbarWidth(
+    value: ScrollbarWidth,
+    component: ScrollableComponent? = null,
+): Modifier = scrollbarWidth(value.value, component)
+
+/** Applies an arbitrary CSS outline shorthand. */
+fun Modifier.outline(value: String): Modifier = style("outline", value)
+
+/** Applies a structured outline declaration. */
+fun Modifier.outline(width: String, style: OutlineStyle, color: String): Modifier =
+    outline("$width ${style.value} $color")
+
+/** Applies a structured outline with a pixel width. */
+fun Modifier.outline(width: Number, style: OutlineStyle, color: String): Modifier =
+    outline(width.px, style, color)
+
+/** Applies a structured outline using a typed color. */
+fun Modifier.outline(width: Number, style: OutlineStyle, color: Color): Modifier =
+    outline(width.px, style, color.toCssString())
+
+/** Sets the distance between an outline and the element's border edge. */
+fun Modifier.outlineOffset(value: String): Modifier = style("outline-offset", value)
+
+/** Sets outline offset in pixels. */
+fun Modifier.outlineOffset(value: Number): Modifier = outlineOffset(value.px)
+
+/**
+ * A composable CSS Grid track value.
+ *
+ * Prefer the factory helpers below to raw strings when building repeated or
+ * min/max track lists.
+ */
+data class GridTrack(val value: String) {
+    init {
+        require(value.isNotBlank()) { "GridTrack value must not be blank" }
+    }
+}
+
+/** Wraps a CSS length, keyword, or named line as a grid track. */
+fun gridTrack(value: String): GridTrack = GridTrack(value)
+
+/** Creates an `fr` grid track. */
+fun gridFraction(value: Number = 1): GridTrack {
+    val numericValue = value.toDouble()
+    require(numericValue.isFinite() && numericValue >= 0.0) {
+        "Grid fraction must be a finite, non-negative number"
+    }
+    return GridTrack("${value.toCssNumber()}fr")
+}
+
+/** Creates a `minmax(...)` grid track. */
+fun gridMinMax(min: GridTrack, max: GridTrack): GridTrack =
+    GridTrack("minmax(${min.value}, ${max.value})")
+
+/** Creates a fixed-count `repeat(...)` grid track group. */
+fun gridRepeat(count: Int, vararg tracks: GridTrack): GridTrack {
+    require(count > 0) { "Grid repeat count must be greater than zero" }
+    return gridRepeat(count.toString(), tracks)
+}
+
+/** Creates an auto-fit `repeat(...)` grid track group. */
+fun gridAutoFit(vararg tracks: GridTrack): GridTrack = gridRepeat("auto-fit", tracks)
+
+/** Creates an auto-fill `repeat(...)` grid track group. */
+fun gridAutoFill(vararg tracks: GridTrack): GridTrack = gridRepeat("auto-fill", tracks)
+
+private fun gridRepeat(repetition: String, tracks: Array<out GridTrack>): GridTrack {
+    require(tracks.isNotEmpty()) { "Grid repeat requires at least one track" }
+    return GridTrack("repeat($repetition, ${tracks.joinToString(" ") { it.value }})")
+}
+
+/** Applies a typed grid-template-columns track list. */
+fun Modifier.gridTemplateColumns(vararg tracks: GridTrack): Modifier {
+    require(tracks.isNotEmpty()) { "gridTemplateColumns requires at least one track" }
+    return gridTemplateColumns(tracks.joinToString(" ") { it.value })
+}
+
+/** Applies a custom grid-template-rows declaration. */
+fun Modifier.gridTemplateRows(value: String): Modifier = style("grid-template-rows", value)
+
+/** Applies a typed grid-template-rows track list. */
+fun Modifier.gridTemplateRows(vararg tracks: GridTrack): Modifier {
+    require(tracks.isNotEmpty()) { "gridTemplateRows requires at least one track" }
+    return gridTemplateRows(tracks.joinToString(" ") { it.value })
+}
+
+private fun Number.toCssNumber(): String {
+    val number = toDouble()
+    return if (number % 1.0 == 0.0) number.toLong().toString() else toString()
+}

--- a/summon-core/src/commonMain/kotlin/codes/yousef/summon/seo/HeadScope.kt
+++ b/summon-core/src/commonMain/kotlin/codes/yousef/summon/seo/HeadScope.kt
@@ -90,7 +90,7 @@ interface HeadScope {
  */
 class DefaultHeadScope(private val onElement: (String) -> Unit) : HeadScope {
     override fun title(text: String) {
-        onElement("<title>$text</title>")
+        onElement("<title>${escapeText(text)}</title>")
     }
 
     override fun meta(
@@ -101,11 +101,11 @@ class DefaultHeadScope(private val onElement: (String) -> Unit) : HeadScope {
         httpEquiv: String?
     ) {
         val attributes = buildString {
-            charset?.let { append(" charset=\"$it\"") }
-            name?.let { append(" name=\"$it\"") }
-            property?.let { append(" property=\"$it\"") }
-            content?.let { append(" content=\"$it\"") }
-            httpEquiv?.let { append(" http-equiv=\"$it\"") }
+            charset?.let { appendAttribute("charset", it) }
+            name?.let { appendAttribute("name", it) }
+            property?.let { appendAttribute("property", it) }
+            content?.let { appendAttribute("content", it) }
+            httpEquiv?.let { appendAttribute("http-equiv", it) }
         }
         if (attributes.isNotEmpty()) {
             onElement("<meta$attributes>")
@@ -121,12 +121,12 @@ class DefaultHeadScope(private val onElement: (String) -> Unit) : HeadScope {
         media: String?
     ) {
         val attributes = buildString {
-            append(" rel=\"$rel\"")
-            append(" href=\"$href\"")
-            type?.let { append(" type=\"$it\"") }
-            sizes?.let { append(" sizes=\"$it\"") }
-            crossorigin?.let { append(" crossorigin=\"$it\"") }
-            media?.let { append(" media=\"$it\"") }
+            appendAttribute("rel", rel)
+            appendAttribute("href", href)
+            type?.let { appendAttribute("type", it) }
+            sizes?.let { appendAttribute("sizes", it) }
+            crossorigin?.let { appendAttribute("crossorigin", it) }
+            media?.let { appendAttribute("media", it) }
         }
         onElement("<link$attributes>")
     }
@@ -141,16 +141,16 @@ class DefaultHeadScope(private val onElement: (String) -> Unit) : HeadScope {
     ) {
         val attributes = buildString {
             if (type != "text/javascript") {
-                append(" type=\"$type\"")
+                appendAttribute("type", type)
             }
-            src?.let { append(" src=\"$it\"") }
+            src?.let { appendAttribute("src", it) }
             if (async) append(" async")
             if (defer) append(" defer")
-            crossorigin?.let { append(" crossorigin=\"$it\"") }
+            crossorigin?.let { appendAttribute("crossorigin", it) }
         }
 
         if (content != null) {
-            onElement("<script$attributes>$content</script>")
+            onElement("<script$attributes>${escapeRawTextEndTag(content, "script")}</script>")
         } else {
             onElement("<script$attributes></script>")
         }
@@ -158,18 +158,57 @@ class DefaultHeadScope(private val onElement: (String) -> Unit) : HeadScope {
 
     override fun style(content: String, media: String?) {
         val attributes = buildString {
-            media?.let { append(" media=\"$it\"") }
+            media?.let { appendAttribute("media", it) }
         }
-        onElement("<style$attributes>$content</style>")
+        onElement("<style$attributes>${escapeRawTextEndTag(content, "style")}</style>")
     }
 
     override fun base(href: String?, target: String?) {
         val attributes = buildString {
-            href?.let { append(" href=\"$it\"") }
-            target?.let { append(" target=\"$it\"") }
+            href?.let { appendAttribute("href", it) }
+            target?.let { appendAttribute("target", it) }
         }
         if (attributes.isNotEmpty()) {
             onElement("<base$attributes>")
         }
     }
+
+    private fun StringBuilder.appendAttribute(name: String, value: String) {
+        append(' ')
+        append(name)
+        append("=\"")
+        append(escapeAttribute(value))
+        append('"')
+    }
+
+    private fun escapeText(value: String): String = buildString(value.length) {
+        value.forEach { character ->
+            append(
+                when (character) {
+                    '&' -> "&amp;"
+                    '<' -> "&lt;"
+                    '>' -> "&gt;"
+                    else -> character
+                }
+            )
+        }
+    }
+
+    private fun escapeAttribute(value: String): String = buildString(value.length) {
+        value.forEach { character ->
+            append(
+                when (character) {
+                    '&' -> "&amp;"
+                    '<' -> "&lt;"
+                    '>' -> "&gt;"
+                    '"' -> "&quot;"
+                    '\'' -> "&#39;"
+                    else -> character
+                }
+            )
+        }
+    }
+
+    private fun escapeRawTextEndTag(value: String, tagName: String): String =
+        value.replace("</$tagName", "<\\/$tagName", ignoreCase = true)
 }

--- a/summon-core/src/commonTest/kotlin/codes/yousef/summon/components/styles/TypedStyleSheetTest.kt
+++ b/summon-core/src/commonTest/kotlin/codes/yousef/summon/components/styles/TypedStyleSheetTest.kt
@@ -1,0 +1,66 @@
+package codes.yousef.summon.components.styles
+
+import codes.yousef.summon.modifier.Display
+import codes.yousef.summon.modifier.MediaQuery
+import codes.yousef.summon.modifier.Modifier
+import codes.yousef.summon.modifier.color
+import codes.yousef.summon.modifier.display
+import codes.yousef.summon.modifier.opacity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TypedStyleSheetTest {
+
+    @Test
+    fun rendersStructuredSelectorsMediaQueriesAndKeyframes() {
+        val navigation = StyleSelector.className("site-navigation")
+        val currentLink = StyleSelector.element(StyleElement.Anchor)
+            .attribute(StyleAttribute.AriaCurrent, "page")
+
+        val css = TypedStyleSheetScope().apply {
+            rule(
+                navigation
+                    .attribute(StyleAttribute.Open)
+                    .child(StyleSelector.element(StyleElement.Summary))
+                    .pseudoClass(StylePseudoClass.FocusVisible),
+                Modifier.color("white")
+            )
+            rule(
+                StyleSelector.element(StyleElement.Input)
+                    .attribute(StyleAttribute.Type, "search")
+                    .pseudoElement(StylePseudoElement.Placeholder),
+                Modifier.opacity(0.7f)
+            )
+            rule(currentLink.or(StyleSelector.className("active-link")), Modifier.display(Display.Block))
+            media(MediaQuery.MaxWidth(640)) {
+                rule(navigation, Modifier.display(Display.None))
+            }
+            keyframes(AnimationName.named("fade-in")) {
+                from(Modifier.opacity(0f))
+                to(Modifier.opacity(1f))
+            }
+        }.render()
+
+        assertEquals(
+            """.site-navigation[open] > summary:focus-visible { color: white; }
+input[type="search"]::placeholder { opacity: 0.7; }
+a[aria-current="page"], .active-link { display: block; }
+@media (max-width: 640px) { .site-navigation { display: none; } }
+@keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }""",
+            css
+        )
+    }
+
+    @Test
+    fun rejectsRawSelectorAndMediaSyntax() {
+        assertFailsWith<IllegalArgumentException> {
+            StyleSelector.className("button:hover")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            TypedStyleSheetScope().media(MediaQuery.Custom("(width > 1px)")) {
+                rule(StyleSelector.Root, Modifier.color("red"))
+            }
+        }
+    }
+}

--- a/summon-core/src/commonTest/kotlin/codes/yousef/summon/modifier/ConditionalStyleModifiersTest.kt
+++ b/summon-core/src/commonTest/kotlin/codes/yousef/summon/modifier/ConditionalStyleModifiersTest.kt
@@ -1,0 +1,103 @@
+package codes.yousef.summon.modifier
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConditionalStyleModifiersTest {
+
+    @Test
+    fun stateModifiersRetainStructuredDefinitionsAndCompatibilityAttributes() {
+        val modifier = Modifier()
+            .hover(mapOf("backgroundImage" to "url(https://example.test/image.png)"))
+            .focus(mapOf("outline" to "2px solid blue"))
+            .active(mapOf("transform" to "scale(0.98)"))
+            .focusWithin(mapOf("borderColor" to "purple"))
+            .firstChild(mapOf("marginTop" to "0"))
+            .lastChild(mapOf("marginBottom" to "0"))
+            .nthChild("2n+1", mapOf("backgroundColor" to "silver"))
+            .onlyChild(mapOf("display" to "block"))
+            .visited(mapOf("color" to "violet"))
+            .disabledStyles(mapOf("opacity" to "0.5"))
+            .checkedStyles(mapOf("accentColor" to "green"))
+
+        val definitions = modifier.conditionalStyles.map { it as StateStyleDefinition }
+
+        assertEquals(
+            listOf(
+                ConditionalStyleState.HOVER,
+                ConditionalStyleState.FOCUS,
+                ConditionalStyleState.ACTIVE,
+                ConditionalStyleState.FOCUS_WITHIN,
+                ConditionalStyleState.FIRST_CHILD,
+                ConditionalStyleState.LAST_CHILD,
+                ConditionalStyleState.NTH_CHILD,
+                ConditionalStyleState.ONLY_CHILD,
+                ConditionalStyleState.VISITED,
+                ConditionalStyleState.DISABLED,
+                ConditionalStyleState.CHECKED,
+            ),
+            definitions.map { it.state },
+        )
+        assertEquals("2n+1", definitions[6].argument)
+        assertEquals(
+            "url(https://example.test/image.png)",
+            definitions.first().styles["backgroundImage"],
+        )
+        assertTrue(modifier.attributes.containsKey("data-hover-styles"))
+        assertTrue(modifier.attributes.containsKey("data-focus-styles"))
+        assertTrue(modifier.attributes.containsKey("data-nth-child-styles"))
+        assertTrue(modifier.attributes.containsKey("data-checked-styles"))
+    }
+
+    @Test
+    fun mediaAndScopedModifiersCreateStructuredRules() {
+        val query = MediaQuery.And(MediaQuery.MinWidth(768), MediaQuery.CanHover)
+        val modifier = Modifier()
+            .mediaQuery(query) {
+                fontSize("18px").style("backgroundImage", "url(https://example.test/wide.png)")
+            }
+            .descendant(".card") { color("navy") }
+            .child("span") { fontWeight(700) }
+
+        val media = modifier.conditionalStyles[0] as MediaStyleDefinition
+        val descendant = modifier.conditionalStyles[1] as ScopedStyleDefinition
+        val child = modifier.conditionalStyles[2] as ScopedStyleDefinition
+
+        assertEquals(query, media.query)
+        assertEquals("url(https://example.test/wide.png)", media.styles["backgroundImage"])
+        assertEquals(SelectorType.DESCENDANT, descendant.selectorType)
+        assertEquals(".card", descendant.selector)
+        assertEquals(SelectorType.CHILD, child.selectorType)
+        assertEquals("span", child.selector)
+        assertTrue(modifier.attributes.containsKey("data-media-queries"))
+        assertTrue(modifier.attributes.containsKey("data-scoped-styles"))
+    }
+
+    @Test
+    fun repeatedHoverCompatibilityEncodingPreservesColonsInValues() {
+        val modifier = Modifier()
+            .hover(mapOf("backgroundImage" to "url(https://example.test/image.png)"))
+            .hover(mapOf("color" to "red"))
+
+        assertEquals(2, modifier.conditionalStyles.size)
+        assertEquals(
+            "backgroundImage:url(https://example.test/image.png);color:red",
+            modifier.attributes["data-hover-styles"],
+        )
+    }
+
+    @Test
+    fun thenCloneAndAttributeRemovalPreserveConditionalRuleOrder() {
+        val first = Modifier()
+            .attribute("data-test", "present")
+            .hover(mapOf("color" to "red"))
+        val second = Modifier().mediaQuery(MediaQuery.MinWidth(960)) { color("blue") }
+        val combined = (first then second).clone().removeAttribute("data-test")
+
+        assertEquals(2, combined.conditionalStyles.size)
+        assertEquals(ConditionalStyleState.HOVER, (combined.conditionalStyles[0] as StateStyleDefinition).state)
+        assertEquals(MediaQuery.MinWidth(960), (combined.conditionalStyles[1] as MediaStyleDefinition).query)
+        assertEquals(null, combined.attributes["data-test"])
+    }
+}

--- a/summon-core/src/commonTest/kotlin/codes/yousef/summon/modifier/TypedCssModifiersTest.kt
+++ b/summon-core/src/commonTest/kotlin/codes/yousef/summon/modifier/TypedCssModifiersTest.kt
@@ -1,0 +1,151 @@
+package codes.yousef.summon.modifier
+
+import codes.yousef.summon.core.style.Color
+import codes.yousef.summon.i18n.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TypedCssModifiersTest {
+
+    @Test
+    fun textDeclarationsMapToCssProperties() {
+        val modifier = Modifier()
+            .textUnderlineOffset(4)
+            .wordBreak(WordBreak.BreakAll)
+            .overflowWrap(OverflowWrap.Anywhere)
+            .textOverflow(TextOverflow.Ellipsis)
+
+        assertEquals("4px", modifier.styles["text-underline-offset"])
+        assertEquals("break-all", modifier.styles["word-break"])
+        assertEquals("anywhere", modifier.styles["overflow-wrap"])
+        assertEquals("ellipsis", modifier.styles["text-overflow"])
+    }
+
+    @Test
+    fun structuredTextShadowsComposeInOrder() {
+        val modifier = Modifier().textShadow(
+            TextShadow.pixels(0, 2, 4, Color.rgba(0, 0, 0, 128)),
+            TextShadow("0", "0", "1rem", "currentColor"),
+        )
+
+        assertEquals(
+            "0px 2px 4px rgba(0, 0, 0, 0.5019608), 0 0 1rem currentColor",
+            modifier.styles["text-shadow"],
+        )
+    }
+
+    @Test
+    fun lineClampIncludesWebkitFallbackByDefault() {
+        val modifier = Modifier().lineClamp(3)
+
+        assertEquals("3", modifier.styles["line-clamp"])
+        assertEquals("3", modifier.styles["-webkit-line-clamp"])
+        assertFailsWith<IllegalArgumentException> { Modifier().lineClamp(0) }
+    }
+
+    @Test
+    fun lineClampFallbackCanBeDisabled() {
+        val modifier = Modifier().lineClamp(2, includeWebkitFallback = false)
+
+        assertEquals("2", modifier.styles["line-clamp"])
+        assertEquals(null, modifier.styles["-webkit-line-clamp"])
+    }
+
+    @Test
+    fun boxAndLogicalInsetDeclarationsAreTyped() {
+        val modifier = Modifier()
+            .boxSizing(BoxSizing.BorderBox)
+            .inset(1, 2, 3, 4)
+            .insetInlineStart(8)
+            .insetInlineEnd("calc(100% - 2rem)")
+
+        assertEquals("border-box", modifier.styles["box-sizing"])
+        assertEquals("1px 2px 3px 4px", modifier.styles["inset"])
+        assertEquals("8px", modifier.styles["inset-inline-start"])
+        assertEquals("calc(100% - 2rem)", modifier.styles["inset-inline-end"])
+    }
+
+    @Test
+    fun colorSchemeAndListMarkersUseTypedValues() {
+        val modifier = Modifier()
+            .colorScheme(ColorScheme.OnlyDark)
+            .listStyle(ListStyleType.None)
+            .listStyleType(ListStyleType.Square)
+
+        assertEquals("only dark", modifier.styles["color-scheme"])
+        assertEquals("none", modifier.styles["list-style"])
+        assertEquals("square", modifier.styles["list-style-type"])
+    }
+
+    @Test
+    fun scrollbarDeclarationsSupportTypedValues() {
+        val modifier = Modifier()
+            .scrollbarWidth(ScrollbarWidth.Thin)
+            .scrollbarColor(Color.hex("#123456"), Color.TRANSPARENT)
+
+        assertEquals("thin", modifier.styles["scrollbar-width"])
+        assertEquals(
+            "rgba(18, 52, 86, 1.0) rgba(0, 0, 0, 0.0)",
+            modifier.styles["scrollbar-color"],
+        )
+    }
+
+    @Test
+    fun outlineDeclarationsComposeWidthStyleColorAndOffset() {
+        val modifier = Modifier()
+            .outline(3, OutlineStyle.Solid, Color.hex("#8fe3ff"))
+            .outlineOffset(2)
+
+        assertEquals("3px solid rgba(143, 227, 255, 1.0)", modifier.styles["outline"])
+        assertEquals("2px", modifier.styles["outline-offset"])
+    }
+
+    @Test
+    fun gridTrackHelpersBuildResponsiveTemplates() {
+        val responsive = gridAutoFit(
+            gridMinMax(gridTrack("280px"), gridFraction()),
+        )
+        val modifier = Modifier()
+            .gridTemplateColumns(responsive)
+            .gridTemplateRows(gridTrack("auto"), gridFraction(2), gridTrack("auto"))
+
+        assertEquals(
+            "repeat(auto-fit, minmax(280px, 1fr))",
+            modifier.styles["grid-template-columns"],
+        )
+        assertEquals("auto 2fr auto", modifier.styles["grid-template-rows"])
+    }
+
+    @Test
+    fun gridTrackHelpersRejectInvalidDefinitions() {
+        assertFailsWith<IllegalArgumentException> { gridTrack(" ") }
+        assertFailsWith<IllegalArgumentException> { gridFraction(-1) }
+        assertFailsWith<IllegalArgumentException> { gridFraction(Double.POSITIVE_INFINITY) }
+        assertFailsWith<IllegalArgumentException> { gridRepeat(0, gridFraction()) }
+        assertFailsWith<IllegalArgumentException> { gridAutoFill() }
+        assertFailsWith<IllegalArgumentException> { Modifier().gridTemplateColumns() }
+        assertFailsWith<IllegalArgumentException> { Modifier().gridTemplateRows() }
+    }
+
+    @Test
+    fun backgroundAttachmentUsesTypedValues() {
+        val modifier = Modifier().backgroundAttachment(BackgroundAttachment.Fixed)
+
+        assertEquals("fixed", modifier.styles["background-attachment"])
+    }
+
+    @Test
+    fun sideBorderKeepsOtherSidesUntouched() {
+        val modifier = Modifier().border(BorderSide.Right, 4, BorderStyle.Solid, "#123456")
+
+        assertEquals("4px solid #123456", modifier.styles["border-right"])
+        assertEquals(null, modifier.styles["border-left"])
+    }
+
+    @Test
+    fun directionUsesFrameworkLayoutDirection() {
+        assertEquals("rtl", Modifier().direction(LayoutDirection.RTL).styles["direction"])
+        assertEquals("ltr", Modifier().direction(LayoutDirection.LTR).styles["direction"])
+    }
+}

--- a/summon-core/src/commonTest/kotlin/codes/yousef/summon/seo/HeadScopeTest.kt
+++ b/summon-core/src/commonTest/kotlin/codes/yousef/summon/seo/HeadScopeTest.kt
@@ -1,0 +1,51 @@
+package codes.yousef.summon.seo
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HeadScopeTest {
+
+    @Test
+    fun escapesTitleTextAndAttributeValues() {
+        val elements = mutableListOf<String>()
+        val head = DefaultHeadScope(elements::add)
+
+        head.title("A < B & C > D")
+        head.meta(
+            name = "description\" onload=\"alert(1)",
+            content = "<tag> & \"quoted\" and 'single'"
+        )
+        head.link(
+            rel = "canonical",
+            href = "https://example.test/?a=1&b=\"two\""
+        )
+
+        assertEquals("<title>A &lt; B &amp; C &gt; D</title>", elements[0])
+        assertEquals(
+            """<meta name="description&quot; onload=&quot;alert(1)" content="&lt;tag&gt; &amp; &quot;quoted&quot; and &#39;single&#39;">""",
+            elements[1]
+        )
+        assertEquals(
+            """<link rel="canonical" href="https://example.test/?a=1&amp;b=&quot;two&quot;">""",
+            elements[2]
+        )
+    }
+
+    @Test
+    fun preventsInlineRawTextFromClosingItsElement() {
+        val elements = mutableListOf<String>()
+        val head = DefaultHeadScope(elements::add)
+
+        head.script(content = "window.value = '</ScRiPt><p>unsafe</p>'")
+        head.style(content = ".demo::after { content: '</StYlE><p>unsafe</p>'; }")
+
+        assertEquals(
+            "<script>window.value = '<\\/script><p>unsafe</p>'</script>",
+            elements[0]
+        )
+        assertEquals(
+            "<style>.demo::after { content: '<\\/style><p>unsafe</p>'; }</style>",
+            elements[1]
+        )
+    }
+}

--- a/summon-core/src/jsMain/kotlin/codes/yousef/summon/runtime/PlatformRenderer.kt
+++ b/summon-core/src/jsMain/kotlin/codes/yousef/summon/runtime/PlatformRenderer.kt
@@ -335,6 +335,11 @@ actual open class PlatformRenderer {
                     StyleInjector.injectPseudoSelectorStyles(element, ":focus", styles)
                 }
 
+                key == "data-focus-visible-styles" -> {
+                    val styles = parseStyleString(value)
+                    StyleInjector.injectPseudoSelectorStyles(element, ":focus-visible", styles)
+                }
+
                 key == "data-active-styles" -> {
                     val styles = parseStyleString(value)
                     StyleInjector.injectPseudoSelectorStyles(element, ":active", styles)
@@ -356,7 +361,12 @@ actual open class PlatformRenderer {
                 }
 
                 key == "data-nth-child-styles" -> {
-                    val parts = value.split("|||")
+                    val parts = if (value.contains("|||")) {
+                        value.split("|||", limit = 2)
+                    } else {
+                        // The common modifier API historically encoded nth-child as "selector:styles".
+                        value.split(":", limit = 2)
+                    }
                     if (parts.size == 2) {
                         val selector = parts[0]
                         val styles = parseStyleString(parts[1])
@@ -394,6 +404,13 @@ actual open class PlatformRenderer {
                             StyleInjector.injectMediaQueryStyles(element, mediaQuery, styles)
                         }
                     }
+                }
+
+                key == "data-scoped-styles" -> {
+                    // Keep the compatibility attribute because processScopedStyles reads the
+                    // serialized definitions from the host element.
+                    element.setAttribute(key, value)
+                    StyleInjector.processScopedStyles(element)
                 }
 
                 else -> {
@@ -857,12 +874,9 @@ actual open class PlatformRenderer {
         modifier: Modifier,
         content: @Composable (FlowContentCompat.() -> Unit)
     ) {
-        val rowModifier = ModifierImpl(
-            modifier.styles + mapOf(
-                "display" to "flex",
-                "flexDirection" to "row"
-            )
-        )
+        val rowModifier = modifier
+            .style("display", "flex")
+            .style("flexDirection", "row")
         createElement("div", rowModifier) {
             content(createFlowContent("div"))
         }
@@ -1438,11 +1452,7 @@ actual open class PlatformRenderer {
         content: @Composable (FlowContentCompat.() -> Unit)
     ) {
         // Create a block element (div with display: block)
-        val blockModifier = ModifierImpl(
-            modifier.styles + mapOf(
-                "display" to "block"
-            )
-        )
+        val blockModifier = modifier.style("display", "block")
 
         createElement("div", blockModifier) {
             content(createFlowContent("div"))
@@ -1454,11 +1464,7 @@ actual open class PlatformRenderer {
         content: @Composable (FlowContentCompat.() -> Unit)
     ) {
         // Create an inline element (span with display: inline)
-        val inlineModifier = ModifierImpl(
-            modifier.styles + mapOf(
-                "display" to "inline"
-            )
-        )
+        val inlineModifier = modifier.style("display", "inline")
 
         createElement("span", inlineModifier) {
             content(createFlowContent("span"))

--- a/summon-core/src/jsMain/kotlin/codes/yousef/summon/runtime/StyleInjector.kt
+++ b/summon-core/src/jsMain/kotlin/codes/yousef/summon/runtime/StyleInjector.kt
@@ -19,14 +19,21 @@ object StyleInjector {
         return "$prefix-${js("Math.random().toString(36).substring(2, 10)") as String}"
     }
 
+    private fun important(value: String): String =
+        if (value.contains("!important", ignoreCase = true)) value else "$value !important"
+
     /**
      * Injects CSS for pseudo-selector styles and returns the class name
      */
     fun injectPseudoSelectorStyles(element: Element, pseudoSelector: String, styles: Map<String, String>): String {
-        val uniqueClass = generateUniqueClass("pseudo-$pseudoSelector")
+        // Pseudo selectors contain ':' and sometimes parentheses, which are not safe in an
+        // unescaped class name. Keep the generated class identifier syntax-neutral.
+        val uniqueClass = generateUniqueClass("pseudo")
         element.classList.add(uniqueClass)
 
-        val cssRules = styles.entries.joinToString("\n  ") { "${it.key}: ${it.value};" }
+        val cssRules = styles.entries.joinToString("\n  ") {
+            "${toKebabCase(it.key)}: ${important(it.value)};"
+        }
         val cssText = ".$uniqueClass$pseudoSelector {\n  $cssRules\n}"
 
         val styleId = "pseudo-$uniqueClass"
@@ -43,7 +50,9 @@ object StyleInjector {
         val uniqueClass = generateUniqueClass("media")
         element.classList.add(uniqueClass)
 
-        val cssRules = styles.entries.joinToString("\n    ") { "${it.key}: ${it.value};" }
+        val cssRules = styles.entries.joinToString("\n    ") {
+            "${toKebabCase(it.key)}: ${important(it.value)};"
+        }
         val cssText = "@media $mediaQuery {\n  .$uniqueClass {\n    $cssRules\n  }\n}"
 
         val styleId = "media-$uniqueClass"
@@ -127,7 +136,7 @@ object StyleInjector {
         }
 
         val cssRules = styles.entries.joinToString("\n    ") {
-            "${toKebabCase(it.key)}: ${it.value};"
+            "${toKebabCase(it.key)}: ${important(it.value)};"
         }
         val cssText = ".$uniqueClass$combinator$targetSelector {\n    $cssRules\n}"
 
@@ -180,4 +189,3 @@ object StyleInjector {
         }
     }
 }
-

--- a/summon-core/src/jsTest/kotlin/codes/yousef/summon/runtime/ConditionalStyleJsTest.kt
+++ b/summon-core/src/jsTest/kotlin/codes/yousef/summon/runtime/ConditionalStyleJsTest.kt
@@ -1,0 +1,59 @@
+package codes.yousef.summon.runtime
+
+import codes.yousef.summon.js.testutil.ensureJsDom
+import codes.yousef.summon.modifier.MediaQuery
+import codes.yousef.summon.modifier.Modifier
+import codes.yousef.summon.modifier.child
+import codes.yousef.summon.modifier.color
+import codes.yousef.summon.modifier.display
+import codes.yousef.summon.modifier.hover
+import codes.yousef.summon.modifier.mediaQuery
+import codes.yousef.summon.modifier.nthChild
+import kotlinx.browser.document
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ConditionalStyleJsTest {
+
+    @BeforeTest
+    fun setUpDom() {
+        ensureJsDom()
+        document.head?.innerHTML = ""
+        document.body?.innerHTML = ""
+    }
+
+    @Test
+    fun jsRendererProcessesStateMediaAndScopedCompatibilityData() {
+        val renderer = PlatformRenderer()
+        val html = renderer.renderComposableRoot {
+            renderer.renderRow(
+                Modifier()
+                    .display("block")
+                    .color("black")
+                    .hover(Modifier().display("none").color("red"))
+                    .nthChild("2n", Modifier().color("green"))
+                    .mediaQuery(MediaQuery.MinWidth(960)) {
+                        display("grid").color("navy")
+                    }
+                    .child(".item") { color("orange") },
+            ) {}
+        }
+
+        val injectedCss = document.head?.textContent.orEmpty()
+
+        assertTrue(html.contains("display:flex") || html.contains("display: flex"))
+        assertTrue(html.contains("color:black") || html.contains("color: black"))
+        assertTrue(html.contains("class=\"pseudo-"))
+        assertTrue(html.contains("scoped-"))
+        assertTrue(!html.contains("pseudo-:"), "Pseudo selector syntax must not leak into class names")
+        assertTrue(injectedCss.contains(":hover"))
+        assertTrue(injectedCss.contains("display: none !important;"))
+        assertTrue(injectedCss.contains("color: red !important;"))
+        assertTrue(injectedCss.contains(":nth-child(2n)"))
+        assertTrue(injectedCss.contains("@media (min-width: 960px)"))
+        assertTrue(injectedCss.contains("display: grid !important;"))
+        assertTrue(injectedCss.contains(" > .item"))
+        assertTrue(injectedCss.contains("color: orange !important;"))
+    }
+}

--- a/summon-core/src/jvmMain/kotlin/codes/yousef/summon/runtime/JvmPlatformRenderer.kt
+++ b/summon-core/src/jvmMain/kotlin/codes/yousef/summon/runtime/JvmPlatformRenderer.kt
@@ -10,7 +10,12 @@ import codes.yousef.summon.components.navigation.Tab
 import codes.yousef.summon.core.FlowContentCompat
 import codes.yousef.summon.core.asFlowContentCompat
 import codes.yousef.summon.hydration.SummonTagConsumer
+import codes.yousef.summon.modifier.ConditionalStyleDefinition
+import codes.yousef.summon.modifier.ConditionalStyleState
+import codes.yousef.summon.modifier.MediaStyleDefinition
 import codes.yousef.summon.modifier.Modifier
+import codes.yousef.summon.modifier.ScopedStyleDefinition
+import codes.yousef.summon.modifier.StateStyleDefinition
 import codes.yousef.summon.modifier.overflowX
 import codes.yousef.summon.modifier.overflowY
 import codes.yousef.summon.modifier.style
@@ -31,6 +36,9 @@ import kotlin.uuid.ExperimentalUuidApi
 actual open class PlatformRenderer {
 
     private val headElements = mutableListOf<String>()
+    private val lastRenderedHeadElements = mutableListOf<String>()
+    private val conditionalStyleRules = linkedSetOf<String>()
+    private var conditionalStyleHostCounter = 0
 
     // Fix 1: Remove ThreadLocal, use instance variable.
     private var currentBuilder: FlowContent? = null
@@ -49,6 +57,216 @@ actual open class PlatformRenderer {
         } else {
             key.replace(Regex("([a-z])([A-Z])"), "$1-$2").lowercase()
         }
+
+    private fun beginConditionalStyleRender() {
+        conditionalStyleRules.clear()
+        conditionalStyleHostCounter = 0
+    }
+
+    private fun endConditionalStyleRender() {
+        conditionalStyleRules.clear()
+        conditionalStyleHostCounter = 0
+    }
+
+    private fun headElementSnapshot(): List<String> =
+        synchronized(headElements) { headElements.toList() }
+
+    private fun clearPendingHeadElements() {
+        synchronized(headElements) { headElements.clear() }
+    }
+
+    private fun rememberRenderedHeadElements(elements: List<String>) {
+        synchronized(lastRenderedHeadElements) {
+            lastRenderedHeadElements.clear()
+            lastRenderedHeadElements.addAll(elements)
+        }
+    }
+
+    private fun List<String>.containsTag(tagName: String): Boolean {
+        val tag = Regex("""<\s*${Regex.escape(tagName)}(?:\s|>)""", RegexOption.IGNORE_CASE)
+        return any(tag::containsMatchIn)
+    }
+
+    private fun List<String>.containsMetaAttribute(attribute: String, value: String): Boolean {
+        val meta = Regex(
+            """<\s*meta\b[^>]*\b${Regex.escape(attribute)}\s*=\s*([\"'])${Regex.escape(value)}\1""",
+            RegexOption.IGNORE_CASE
+        )
+        return any(meta::containsMatchIn)
+    }
+
+    private fun List<String>.containsCharsetMeta(): Boolean {
+        val meta = Regex("""<\s*meta\b[^>]*\bcharset\s*=""", RegexOption.IGNORE_CASE)
+        return any(meta::containsMatchIn)
+    }
+
+    private fun defaultAwareHeadElements(customElements: List<String>): List<String> = buildList {
+        if (!customElements.containsCharsetMeta()) {
+            add("<meta charset=\"UTF-8\">")
+        }
+        if (!customElements.containsMetaAttribute("name", "viewport")) {
+            add("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">")
+        }
+        if (!customElements.containsTag("title")) {
+            add("<title>Summon App</title>")
+        }
+        if (!customElements.containsMetaAttribute("name", "description")) {
+            add("<meta name=\"description\" content=\"Summon Framework Application\">")
+        }
+        if (!customElements.containsMetaAttribute("name", "robots")) {
+            add("<meta name=\"robots\" content=\"index, follow\">")
+        }
+        if (!customElements.containsMetaAttribute("property", "og:type")) {
+            add("<meta property=\"og:type\" content=\"website\">")
+        }
+        if (
+            !customElements.containsMetaAttribute("property", "og:title") &&
+            !customElements.containsTag("title")
+        ) {
+            add("<meta property=\"og:title\" content=\"Summon App\">")
+        }
+        addAll(customElements)
+    }
+
+    private fun escapeHtmlAttribute(value: String): String = buildString(value.length) {
+        value.forEach { character ->
+            when (character) {
+                '&' -> append("&amp;")
+                '<' -> append("&lt;")
+                '>' -> append("&gt;")
+                '"' -> append("&quot;")
+                '\'' -> append("&#39;")
+                else -> append(character)
+            }
+        }
+    }
+
+    private fun injectHeadElements(document: String, elements: List<String>): String {
+        if (elements.isEmpty()) return document
+        val headEnd = document.indexOf("</head>")
+        if (headEnd < 0) return document
+        return document.substring(0, headEnd) + elements.joinToString("\n") + document.substring(headEnd)
+    }
+
+    private fun removeSupersededDefaultHeadElements(
+        document: String,
+        customElements: List<String>
+    ): String {
+        var updated = document
+        if (customElements.containsCharsetMeta()) {
+            updated = updated.replace("<meta charset=\"UTF-8\">", "")
+        }
+        if (customElements.containsMetaAttribute("name", "viewport")) {
+            updated = updated.replace(
+                "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">",
+                ""
+            )
+        }
+        if (customElements.containsTag("title")) {
+            updated = updated.replace("<title>Summon App</title>", "")
+        }
+        if (customElements.containsMetaAttribute("name", "description")) {
+            updated = updated.replace(
+                "<meta name=\"description\" content=\"Summon Framework Application\">",
+                ""
+            )
+        }
+        if (customElements.containsMetaAttribute("name", "robots")) {
+            updated = updated.replace("<meta name=\"robots\" content=\"index, follow\">", "")
+        }
+        if (customElements.containsMetaAttribute("property", "og:type")) {
+            updated = updated.replace("<meta property=\"og:type\" content=\"website\">", "")
+        }
+        if (
+            customElements.containsMetaAttribute("property", "og:title") ||
+            customElements.containsTag("title")
+        ) {
+            updated = updated.replace("<meta property=\"og:title\" content=\"Summon App\">", "")
+        }
+        return updated
+    }
+
+    private fun stateSelector(definition: StateStyleDefinition): String =
+        when (definition.state) {
+            ConditionalStyleState.HOVER -> ":hover"
+            ConditionalStyleState.FOCUS -> ":focus"
+            ConditionalStyleState.FOCUS_VISIBLE -> ":focus-visible"
+            ConditionalStyleState.ACTIVE -> ":active"
+            ConditionalStyleState.FOCUS_WITHIN -> ":focus-within"
+            ConditionalStyleState.FIRST_CHILD -> ":first-child"
+            ConditionalStyleState.LAST_CHILD -> ":last-child"
+            ConditionalStyleState.NTH_CHILD -> ":nth-child(${definition.argument})"
+            ConditionalStyleState.ONLY_CHILD -> ":only-child"
+            ConditionalStyleState.VISITED -> ":visited"
+            ConditionalStyleState.DISABLED -> ":disabled"
+            ConditionalStyleState.CHECKED -> ":checked"
+        }
+
+    private fun cssDeclarations(styles: Map<String, String>, indent: String): String =
+        styles.entries.joinToString("\n") { (property, value) ->
+            val importantValue = if (value.contains("!important", ignoreCase = true)) {
+                value
+            } else {
+                "$value !important"
+            }
+            "$indent${cssPropertyName(property)}: $importantValue;"
+        }
+
+    private fun renderConditionalStyleRule(
+        hostSelector: String,
+        definition: ConditionalStyleDefinition
+    ): String = when (definition) {
+        is StateStyleDefinition -> buildString {
+            append(hostSelector)
+            append(stateSelector(definition))
+            append(" {\n")
+            append(cssDeclarations(definition.styles, "  "))
+            append("\n}")
+        }
+
+        is MediaStyleDefinition -> buildString {
+            append("@media ")
+            append(definition.query)
+            append(" {\n  ")
+            append(hostSelector)
+            append(" {\n")
+            append(cssDeclarations(definition.styles, "    "))
+            append("\n  }\n}")
+        }
+
+        is ScopedStyleDefinition -> buildString {
+            append(hostSelector)
+            append(definition.selectorType.combinator)
+            append(definition.selector)
+            append(" {\n")
+            append(cssDeclarations(definition.styles, "  "))
+            append("\n}")
+        }
+    }
+
+    private fun registerConditionalStyles(
+        hostId: String,
+        definitions: List<ConditionalStyleDefinition>
+    ) {
+        val hostSelector = "[data-summon-style-id=\"$hostId\"]"
+        definitions
+            .filter { it.styles.isNotEmpty() }
+            .mapTo(conditionalStyleRules) { renderConditionalStyleRule(hostSelector, it) }
+    }
+
+    private fun injectConditionalStyleSheet(document: String): String {
+        if (conditionalStyleRules.isEmpty()) return document
+
+        val headEnd = document.indexOf("</head>")
+        if (headEnd < 0) return document
+
+        val styleElement = buildString {
+            append("<style data-summon-conditional-styles=\"true\">\n")
+            append(conditionalStyleRules.joinToString("\n"))
+            append("\n</style>")
+        }
+        return document.substring(0, headEnd) + styleElement + document.substring(headEnd)
+    }
 
     // Apply Modifier - handles both styles and attributes
     // This extension function applies to any FlowOrMetaDataContent
@@ -102,6 +320,12 @@ actual open class PlatformRenderer {
                         }
                     }
                 }
+            }
+
+            if (modifier.conditionalStyles.isNotEmpty()) {
+                val styleHostId = "summon-style-${conditionalStyleHostCounter++}"
+                this.attributes["data-summon-style-id"] = styleHostId
+                registerConditionalStyles(styleHostId, modifier.conditionalStyles)
             }
         }
 
@@ -343,7 +567,12 @@ actual open class PlatformRenderer {
     }
 
     actual open fun getHeadElements(): List<String> {
-        return headElements.toList()
+        val pending = headElementSnapshot()
+        return if (pending.isNotEmpty()) {
+            pending
+        } else {
+            synchronized(lastRenderedHeadElements) { lastRenderedHeadElements.toList() }
+        }
     }
 
     actual open fun renderHeadElements(builder: codes.yousef.summon.seo.HeadScope.() -> Unit) {
@@ -379,15 +608,16 @@ actual open class PlatformRenderer {
     }
 
     actual open fun renderComposableRoot(composable: @Composable (() -> Unit)): String {
+        beginConditionalStyleRender()
+        val initialHeadElements = headElementSnapshot()
         CallbackRegistry.beginRender()
         val result = StringBuilder()
         try {
             result.appendHTML(prettyPrint = false).html {
                 head {
-                    meta(charset = "UTF-8")
-                    meta(name = "viewport", content = "width=device-width, initial-scale=1.0")
-                    title("Summon App")
-                    synchronized(headElements) { headElements.forEach { unsafe { raw(it) } } }
+                    defaultAwareHeadElements(initialHeadElements).forEach { element ->
+                        unsafe { raw(element) }
+                    }
                 }
                 body {
                     currentBuilder = this // Set context
@@ -398,13 +628,24 @@ actual open class PlatformRenderer {
                     }
                 }
             }
+            val completeHeadElements = headElementSnapshot()
+            rememberRenderedHeadElements(completeHeadElements)
+            val lateHeadElements = completeHeadElements.drop(initialHeadElements.size)
+            val defaultAwareDocument = removeSupersededDefaultHeadElements(
+                result.toString(),
+                lateHeadElements
+            )
+            return injectConditionalStyleSheet(
+                injectHeadElements(defaultAwareDocument, lateHeadElements)
+            )
         } finally {
             if (currentBuilder != null) { // Double-check clearance on exception
                 currentBuilder = null
             }
             CallbackRegistry.abandonRenderContext()
+            endConditionalStyleRender()
+            clearPendingHeadElements()
         }
-        return result.toString()
     }
 
     private val BOOTLOADER_SCRIPT = """
@@ -561,6 +802,7 @@ actual open class PlatformRenderer {
         dir: String = "ltr",
         composable: @Composable () -> Unit
     ): String {
+        beginConditionalStyleRender()
         val debugEnabled = System.getProperty("summon.debug.callbacks", "false").toBoolean()
         
         if (debugEnabled) {
@@ -591,7 +833,10 @@ actual open class PlatformRenderer {
             }
             
             val hydrationData = generateHydrationData(callbackIds)
-            val fullDoc = createHydratedDocument(bodyContent, hydrationData, state, lang, dir)
+            rememberRenderedHeadElements(headElementSnapshot())
+            val fullDoc = injectConditionalStyleSheet(
+                createHydratedDocument(bodyContent, hydrationData, state, lang, dir)
+            )
             
             if (debugEnabled) {
                 // Extract callback IDs from the HTML for verification
@@ -604,6 +849,8 @@ actual open class PlatformRenderer {
             fullDoc
         } finally {
             CallbackRegistry.abandonRenderContext()
+            endConditionalStyleRender()
+            clearPendingHeadElements()
         }
     }
 
@@ -676,61 +923,38 @@ actual open class PlatformRenderer {
         }
 
         val bootloader = """<script>$BOOTLOADER_SCRIPT</script>"""
+        val documentHead = defaultAwareHeadElements(headElementSnapshot()).joinToString("\n    ")
+        val documentLanguage = escapeHtmlAttribute(lang)
+        val documentDirection = escapeHtmlAttribute(dir)
 
         return """<!DOCTYPE html>
-<html lang="$lang" dir="$dir">
+<html lang="$documentLanguage" dir="$documentDirection">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Summon App</title>
-
-    <!-- SEO-critical metadata is preserved for search engines -->
-    <meta name="description" content="Summon Framework Application">
-    <meta name="robots" content="index, follow">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Summon App">
-
+    $documentHead
     $bootloader
     $stateScript
-
-    ${headElements.joinToString("\n    ")}
-
-    <!-- Preload hydration resources for better performance -->
     <link rel="preload" href="/summon-hydration.js" as="script">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="dns-prefetch" href="//fonts.googleapis.com">
 </head>
 <body>
-    <!-- Server-rendered content with hydration markers -->
     <div id="${SummonConstants.DEFAULT_ROOT_ELEMENT_ID}" data-ssr="true" data-hydration-ready="false" data-summon-hydration="root">
         $bodyContent
     </div>
-
-    <!-- Hydration data for Summon components -->
     <script type="application/json" id="summon-hydration-data">
         $hydrationData
     </script>
-
-    <!-- Progressive enhancement: Forms work without JS -->
-                <noscript>
-                    <style>
-                        [data-onclick-action], [data-onchange-action] {
-                            /* Ensure form elements are visible and functional without JS */
-                            opacity: 1 !important;
-                            pointer-events: auto !important;
-                        }
-                    </style>
-                </noscript>
-
-                <!-- Phase 5: Performance optimization meta tags and resource hints -->
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-                <!-- Preconnect to optimize external resources -->
-                <link rel="preconnect" href="https://fonts.gstatic.com">
-                <link rel="dns-prefetch" href="//fonts.googleapis.com">
-
-                <!-- Minimal bootloader - external script loaded with defer for TBT optimization -->
-                <script src="/summon-bootloader.js" defer></script>
-            </body>
-            </html>
+    <noscript>
+        <style>
+            [data-onclick-action], [data-onchange-action] {
+                opacity: 1 !important;
+                pointer-events: auto !important;
+            }
+        </style>
+    </noscript>
+    <script src="/summon-bootloader.js" defer></script>
+</body>
+</html>
         """.trimIndent()
     }
 
@@ -1525,17 +1749,6 @@ actual open class PlatformRenderer {
         }
 
         return if (attrs.isNotEmpty()) " ${attrs.joinToString(" ")}" else ""
-    }
-
-    /**
-     * Escapes special characters for use in HTML attribute values.
-     */
-    private fun escapeHtmlAttribute(value: String): String {
-        return value
-            .replace("&", "&amp;")
-            .replace("\"", "&quot;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
     }
 
     actual open fun renderCanvas(

--- a/summon-core/src/jvmTest/kotlin/codes/yousef/summon/components/forms/FormComponentsJvmTest.kt
+++ b/summon-core/src/jvmTest/kotlin/codes/yousef/summon/components/forms/FormComponentsJvmTest.kt
@@ -21,7 +21,29 @@ class FormComponentsJvmTest {
                     defaultValue = "Sample Project",
                     required = true
                 )
-                FormButton(text = "Save")
+                FormTextField(
+                    name = "dueDate",
+                    label = "Due date",
+                    defaultValue = "2026-07-17",
+                    type = FormTextFieldType.Date
+                )
+                FormTextField(
+                    name = "amount",
+                    label = "Amount",
+                    defaultValue = "12.50",
+                    type = FormTextFieldType.Number,
+                    step = 0.01
+                )
+                FormRadioGroup(
+                    name = "mode",
+                    label = "Mode",
+                    options = listOf(
+                        FormRadioOption("set", "Set"),
+                        FormRadioOption("shift", "Shift")
+                    ),
+                    selectedValue = "set"
+                )
+                FormButton(text = "Save", name = "action", value = "apply", formId = "detached-form")
             }
         }
 
@@ -32,5 +54,11 @@ class FormComponentsJvmTest {
         assertTrue(html.contains("""name="title""""), "text field should include name attribute")
         assertTrue(html.contains("""value="Sample Project""""), "default value should be serialized")
         assertTrue(html.contains("""type="submit""""), "submit button should be native")
+        assertTrue(html.contains("""type="date""""), "date field should use the native input type")
+        assertTrue(html.contains("""step="0.01""""), "numeric step should be serialized")
+        assertTrue(html.contains("""type="radio""""), "radio group should use native inputs")
+        assertTrue(html.contains("""name="action""""), "submit button name should be serialized")
+        assertTrue(html.contains("""value="apply""""), "submit button value should be serialized")
+        assertTrue(html.contains("""form="detached-form""""), "associated form id should be serialized")
     }
 }

--- a/summon-core/src/jvmTest/kotlin/codes/yousef/summon/runtime/JvmConditionalStyleRenderingTest.kt
+++ b/summon-core/src/jvmTest/kotlin/codes/yousef/summon/runtime/JvmConditionalStyleRenderingTest.kt
@@ -1,0 +1,87 @@
+package codes.yousef.summon.runtime
+
+import codes.yousef.summon.modifier.MediaQuery
+import codes.yousef.summon.modifier.Modifier
+import codes.yousef.summon.modifier.active
+import codes.yousef.summon.modifier.child
+import codes.yousef.summon.modifier.color
+import codes.yousef.summon.modifier.display
+import codes.yousef.summon.modifier.focus
+import codes.yousef.summon.modifier.focusWithin
+import codes.yousef.summon.modifier.hover
+import codes.yousef.summon.modifier.mediaQuery
+import codes.yousef.summon.modifier.nthChild
+import codes.yousef.summon.modifier.style
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class JvmConditionalStyleRenderingTest {
+
+    @Test
+    fun nonHydratedSsrEmitsStructuredConditionalCssInTheSameDocument() {
+        val renderer = PlatformRenderer()
+        val html = renderer.renderComposableRoot {
+            renderer.renderDiv(
+                Modifier()
+                    .display("block")
+                    .color("black")
+                    .hover(
+                        Modifier()
+                            .display("none")
+                            .color("red")
+                            .style("backgroundImage", "url(https://example.test/hover.png)")
+                    )
+                    .focus(Modifier().color("blue"))
+                    .active(Modifier().style("transform", "scale(0.98)"))
+                    .focusWithin(Modifier().style("borderColor", "purple"))
+                    .nthChild("2n", Modifier().color("green"))
+                    .mediaQuery(MediaQuery.MinWidth(960)) {
+                        display("grid").color("navy")
+                    }
+                    .child(".item") { color("orange") },
+            ) {}
+        }
+
+        assertTrue(html.contains("style=\"display: block; color: black;\""))
+        assertTrue(html.contains("data-summon-style-id=\"summon-style-0\""))
+        assertTrue(html.contains("<style data-summon-conditional-styles=\"true\">"))
+        assertTrue(html.contains("[data-summon-style-id=\"summon-style-0\"]:hover"))
+        assertTrue(html.contains("display: none !important;"))
+        assertTrue(html.contains("color: red !important;"))
+        assertTrue(html.contains("background-image: url(https://example.test/hover.png) !important;"))
+        assertTrue(html.contains(":focus"))
+        assertTrue(html.contains(":active"))
+        assertTrue(html.contains(":focus-within"))
+        assertTrue(html.contains(":nth-child(2n)"))
+        assertTrue(html.contains("@media (min-width: 960px)"))
+        assertTrue(html.contains("display: grid !important;"))
+        assertTrue(html.contains("] > .item"))
+        assertTrue(html.indexOf("<style data-summon-conditional-styles") < html.indexOf("</head>"))
+        assertEquals(1, html.split("<style data-summon-conditional-styles").size - 1)
+    }
+
+    @Test
+    fun hydratedSsrResetsDeterministicStyleMarkersBetweenDocuments() {
+        val renderer = PlatformRenderer()
+        val modifier = Modifier()
+            .color("black")
+            .hover(Modifier().color("white"))
+            .mediaQuery(MediaQuery.MaxWidth(640)) { display("none") }
+
+        val first = renderer.renderComposableRootWithHydration {
+            renderer.renderDiv(modifier) {}
+        }
+        val second = renderer.renderComposableRootWithHydration {
+            renderer.renderDiv(modifier) {}
+        }
+
+        listOf(first, second).forEach { html ->
+            assertTrue(html.contains("data-summon-style-id=\"summon-style-0\""))
+            assertTrue(html.contains("[data-summon-style-id=\"summon-style-0\"]:hover"))
+            assertTrue(html.contains("color: white !important;"))
+            assertTrue(html.contains("@media (max-width: 640px)"))
+            assertTrue(html.contains("display: none !important;"))
+        }
+    }
+}

--- a/summon-core/src/jvmTest/kotlin/codes/yousef/summon/runtime/JvmHeadRenderingTest.kt
+++ b/summon-core/src/jvmTest/kotlin/codes/yousef/summon/runtime/JvmHeadRenderingTest.kt
@@ -1,0 +1,68 @@
+package codes.yousef.summon.runtime
+
+import codes.yousef.summon.components.display.Text
+import codes.yousef.summon.seo.MetaTags
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class JvmHeadRenderingTest {
+
+    @Test
+    fun customMetadataReplacesDefaultsAndIsEscaped() {
+        val renderer = PlatformRenderer()
+        renderer.renderHeadElements {
+            title("Packages <Seen> & friends")
+            meta(name = "description", content = "A \"safe\" <catalog> & index")
+            meta(property = "og:title", content = "Packages <Seen>")
+        }
+
+        val html = renderer.renderComposableRootWithHydration("en", "ltr") {
+            Text("Catalog")
+        }
+
+        assertEquals(1, Regex("<title>").findAll(html).count())
+        assertEquals(1, Regex("name=\"description\"").findAll(html).count())
+        assertEquals(1, Regex("property=\"og:title\"").findAll(html).count())
+        assertEquals(1, Regex("name=\"viewport\"").findAll(html).count())
+        assertContains(html, "<title>Packages &lt;Seen&gt; &amp; friends</title>")
+        assertContains(html, "content=\"A &quot;safe&quot; &lt;catalog&gt; &amp; index\"")
+        assertFalse(html.substringAfter("<body>").contains("<meta"))
+    }
+
+    @Test
+    fun metadataAndGeneratedHeadStylesDoNotLeakAcrossRendererReuse() {
+        val renderer = PlatformRenderer()
+
+        val first = renderer.renderComposableRoot {
+            MetaTags(title = "First page", description = "First description")
+            Text("First")
+        }
+        val second = renderer.renderComposableRoot {
+            Text("Second")
+        }
+
+        assertContains(first, "<title>First page</title>")
+        assertContains(first, "First description")
+        assertFalse(second.contains("First page"))
+        assertFalse(second.contains("First description"))
+        assertContains(second, "<title>Summon App</title>")
+    }
+
+    @Test
+    fun languageAndDirectionAttributesAreEscaped() {
+        val renderer = PlatformRenderer()
+
+        val html = renderer.renderComposableRootWithHydration(
+            lang = "en\" data-hostile=\"true",
+            dir = "ltr<unsafe",
+        ) {
+            Text("Content")
+        }
+
+        assertContains(html, "lang=\"en&quot; data-hostile=&quot;true\"")
+        assertContains(html, "dir=\"ltr&lt;unsafe\"")
+        assertFalse(html.contains("data-hostile=\"true\""))
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
 # Centralized version information for Summon
 # This file is the single source of truth for version information
 # and is used by both the main project and example projects
-VERSION=0.7.0.2
+VERSION=0.7.0.3
 GROUP=codes.yousef
 ARTIFACT_ID=summon


### PR DESCRIPTION
## Summary

- add a structured typed stylesheet DSL for selectors, media queries, pseudo states/elements, keyframes, and priorities
- make conditional modifier styles render in JVM SSR and attach browser state hooks
- add the typed CSS and native form metadata required by framework-only applications
- harden head escaping, late head composition, default replacement, and per-render isolation
- preserve prior JVM form signatures while publishing Summon `0.7.0.3`

## Verification

- `./gradlew :summon-core:jvmTest`
- `./gradlew :summon-core:jsTest`
- `./gradlew :summon-core:wasmJsTest`
- `./gradlew :summon-core:apiCheck`
- `./gradlew :summon-cli:jvmTest` (26/26, including generated full-stack templates)
- `./gradlew publishToMavenLocal -Dmaven.repo.local=/tmp/fel642-m2`
- portfolio and isolated registry suites pass against the locally published `0.7.0.3`

Tracks FEL-642.